### PR TITLE
Lifeline: finish hermetic validation and document operator flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ Proof-pass receipt refs normalize path-like values to forward slashes, and `proo
 
 Worker-originated requests can add `source_refs` for `_stack` assignment, status, merge, or handoff artifacts. Lifeline preserves those refs in the emitted receipt so the execution trail stays anchored to worker context instead of hidden transcripts.
 
+## Intended operator flow
+
+Use the operator path in this order so environment drift, manifest drift, and receipt emission stay explicit:
+
+1. `pnpm lifeline doctor`
+2. `pnpm lifeline validate <manifest> [--playbook-path <path>]`
+3. the intended runtime action (`up`, `restart`, `status`, or `execute`)
+4. the auditable receipt step (`execute` writes an execution receipt for every attempt; `proof-pass` writes a deterministic `proof_passed` receipt when the referenced ATLAS summary is clean and `completion_ready=true`)
+
+- Rule: validation must execute through the same CLI boundary operators use for real runtime-facing work.
+- Pattern: run the shared preflight first, validate through the canonical CLI boundary second, then emit deterministic receipts with an explicit first remediation step when receipt emission is blocked.
+- Failure Mode: temp-transpiled helper paths and late environment discovery create noisy module-boundary failures that do not describe the real operator path.
+
 ## Optional Playbook integration
 
 Playbook is treated as one repo with two separate roles:
@@ -137,6 +150,7 @@ Playbook archetype exports are sparse optional default bundles. They may omit an
 ## Validation and resolution behavior
 
 - `lifeline doctor` runs the shared preflight contract that validation uses before it reads manifests.
+- `lifeline doctor` is the explicit way to inspect the same environment boundary that `lifeline validate` will enforce.
 - `lifeline validate <manifest>` validates the raw manifest structure only.
 - `lifeline validate` fails fast on Node, package-manager, shell, or repo prerequisite mismatches before manifest validation starts.
 - `lifeline validate <manifest> --playbook-path <path>` validates the resolved config, so required runtime fields may come from Playbook defaults.
@@ -145,7 +159,7 @@ Playbook archetype exports are sparse optional default bundles. They may omit an
 - The runtime `port` requirement can come from either Playbook defaults or explicit manifest values.
 - `lifeline resolve <manifest>` prints the fully resolved config that Lifeline would execute.
 - `lifeline up` and `lifeline restart` use the same resolution path as `resolve`.
-- The standalone `scripts/validate-fitness-mirror.mjs` helper delegates to `lifeline validate` so mirror validation uses the same CLI boundary as normal runtime-facing validation paths.
+- The standalone `scripts/validate-fitness-mirror.mjs` helper delegates to `lifeline validate` so mirror validation uses the same CLI boundary as normal runtime-facing validation paths instead of importing temp-transpiled outputs.
 - If an app was started with Playbook defaults, Lifeline stores the resolved Playbook path in `.lifeline/state.json` so `restart` remains deterministic without retyping flags.
 
 ## Preflight troubleshooting
@@ -158,6 +172,12 @@ If `lifeline validate` fails before manifest parsing, run `pnpm lifeline doctor`
 - missing repository prerequisites such as the lockfile
 
 The failure surface is intentionally short: category plus first remediation step should fit in one screen.
+
+Windows/Node troubleshooting notes:
+
+- Treat helper-vs-CLI validation differences as boundary bugs. Use `pnpm lifeline validate` or `node scripts/validate-fitness-mirror.mjs` as the canonical path.
+- Do not treat temp-transpiled `.js` outputs in typeless temp roots as canonical evidence on Windows. Those paths can trigger Node 22 module-format drift that does not exist in the real Lifeline runtime boundary.
+- If preflight fails, fix that environment issue before chasing manifest errors. Late environment discovery makes validation noisy and hides the actual root cause.
 
 ## Runtime behavior
 
@@ -377,6 +397,8 @@ YAML parsing and env-file parsing are implemented inside the repo because the co
 
 - [Scope](docs/scope.md)
 - [Architecture](docs/architecture.md)
+- [Hermetic validation runbook](docs/runbooks/hermetic-validation-operator-flow.md)
+- [Operator surface](docs/ops/lifeline-operator-surface.md)
 - [Startup contract (Wave 2)](docs/startup-contract.md)
 - [Privileged execution](docs/privileged-execution.md)
 - [UI proof-passed receipt contract](docs/contracts/ui-proof-passed-receipt-contract.md)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Lifeline provides a boring, low-maintenance way to describe how an app should be
 ```bash
 pnpm install
 pnpm build
+pnpm lifeline doctor
 pnpm lifeline validate examples/fitness-app.lifeline.yml
 pnpm lifeline resolve fixtures/runtime-smoke-app/runtime-smoke-app.lifeline.yml
 pnpm lifeline resolve fixtures/runtime-smoke-app/runtime-smoke-app.playbook.lifeline.yml --playbook-path fixtures/playbook-export
@@ -86,6 +87,8 @@ pnpm lifeline proof-pass ../../runtime/atlas/ui-proof/fitness/latest.json \
   --tranche F11
 pnpm lifeline down runtime-smoke-app
 ```
+
+Proof-pass receipt refs normalize path-like values to forward slashes, and `proof-pass` prints a failure category plus a first remediation step when emission fails.
 
 Worker-originated requests can add `source_refs` for `_stack` assignment, status, merge, or handoff artifacts. Lifeline preserves those refs in the emitted receipt so the execution trail stays anchored to worker context instead of hidden transcripts.
 
@@ -133,14 +136,28 @@ Playbook archetype exports are sparse optional default bundles. They may omit an
 
 ## Validation and resolution behavior
 
+- `lifeline doctor` runs the shared preflight contract that validation uses before it reads manifests.
 - `lifeline validate <manifest>` validates the raw manifest structure only.
+- `lifeline validate` fails fast on Node, package-manager, shell, or repo prerequisite mismatches before manifest validation starts.
 - `lifeline validate <manifest> --playbook-path <path>` validates the resolved config, so required runtime fields may come from Playbook defaults.
 - Lifeline treats Playbook archetypes as optional default bundles and validates only fields that are present in those exports.
 - Lifeline enforces runnable requirements only on the final resolved config after defaults+manifest merge.
 - The runtime `port` requirement can come from either Playbook defaults or explicit manifest values.
 - `lifeline resolve <manifest>` prints the fully resolved config that Lifeline would execute.
 - `lifeline up` and `lifeline restart` use the same resolution path as `resolve`.
+- The standalone `scripts/validate-fitness-mirror.mjs` helper delegates to `lifeline validate` so mirror validation uses the same CLI boundary as normal runtime-facing validation paths.
 - If an app was started with Playbook defaults, Lifeline stores the resolved Playbook path in `.lifeline/state.json` so `restart` remains deterministic without retyping flags.
+
+## Preflight troubleshooting
+
+If `lifeline validate` fails before manifest parsing, run `pnpm lifeline doctor` first. The shared preflight contract reports the first actionable remediation for:
+
+- Node version mismatches against the repository engine range
+- package-manager drift from the `packageManager` contract
+- shell/runtime probe failures
+- missing repository prerequisites such as the lockfile
+
+The failure surface is intentionally short: category plus first remediation step should fit in one screen.
 
 ## Runtime behavior
 
@@ -343,6 +360,8 @@ Rule: Mirrors must not be validated as canonical sources unless they fully satis
 Pattern: Separate canonical manifest validation from narrow local mirror validation.
 
 Failure Mode: Partial mirrors routed through canonical validators create misleading missing-field failures.
+
+Troubleshooting: if validation behavior differs between a helper script and `lifeline validate`, treat that as a boundary bug. Validation helpers should delegate to the CLI boundary instead of importing temp-transpiled `.js` outputs directly, because typeless temp roots can trigger Node 22 module-format drift on Windows.
 
 ## Minimal dependency policy
 

--- a/docs/PLAYBOOK_NOTES.md
+++ b/docs/PLAYBOOK_NOTES.md
@@ -3,6 +3,22 @@
 Use this file to record meaningful code changes in a concise, reviewable format.
 Link related pull requests whenever possible.
 
+## 2026-04-21
+
+- WHAT changed:
+  - Reframed README, architecture, scope, and operator docs around the shared preflight contract and the hermetic `doctor -> validate -> runtime -> receipt/proof-pass` path.
+  - Added a concise operator runbook for validation, runtime action, deterministic execution receipts, and proof-backed completion receipts.
+  - Tightened the README command-surface test so the documented CLI surface must continue to include `execute` and `proof-pass`.
+- WHY it changed:
+  - Wave 1 changed the real operator seam, but the docs still mixed startup-wave language with the newer preflight and receipt model.
+  - Operators need one canonical path that explains where environment failures stop, where manifest validation begins, and how deterministic receipts surface the first remediation step.
+- Rule:
+  - Validation must execute through the same CLI boundary operators use for real runtime-facing work.
+- Pattern:
+  - Shared preflight first, canonical validate second, runtime action third, deterministic receipt last.
+- Failure mode addressed:
+  - Temp transpile paths and late environment discovery can create noisy module-boundary failures that do not match the real Lifeline boundary.
+
 ## 2026-03-25
 
 - WHAT changed:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Lifeline uses a simple four-part architecture.
+Lifeline uses a small operator architecture with explicit preflight, validation, runtime, and receipt boundaries.
 
 ## 1. Manifest contract
 
@@ -17,10 +17,27 @@ Playbook is one repo with two roles:
 
 Lifeline only consumes Playbook export files from disk. There are no HTTP calls, no requirement that the Playbook UI be running, and no runtime dependency on an external service.
 
-## 3. CLI operator
+## 3. Shared preflight + hermetic validate boundary
+
+The preflight contract is the environment gate in front of manifest validation:
+
+- `doctor` runs the shared preflight contract and prints the operator-facing success or failure surface without reading a manifest
+- `validate` runs the same preflight contract before it loads a manifest or resolves Playbook defaults
+- preflight failures stay short and actionable: category plus first remediation step
+- preflight currently covers Node engine range, package-manager contract, shell-runtime probes, and repo prerequisites such as the lockfile
+- the standalone `scripts/validate-fitness-mirror.mjs` helper delegates back to `lifeline validate` so mirror validation stays on the same CLI boundary instead of importing temp-transpiled outputs directly
+
+This is the hermetic validation rule for the repo:
+
+- Rule: validation must execute through the same boundary operators use for real runtime-facing work.
+- Pattern: inspect the environment first, then validate the resolved or raw manifest through the CLI.
+- Failure Mode: helper-only temp transpile paths can create fake Windows/Node module-boundary failures that do not exist on the real Lifeline path.
+
+## 4. CLI operator
 
 The CLI is the operator-facing entrypoint. Current commands:
 
+- `doctor`
 - `validate`
 - `resolve`
 - `up`
@@ -30,10 +47,12 @@ The CLI is the operator-facing entrypoint. Current commands:
 - `restart`
 - `restore`
 - `startup` (merged Wave 2 backend seam with registered platform installers)
+- `execute`
+- `proof-pass`
 
 `up` resolves config and runs install/build, then launches a detached Lifeline supervisor process (not the app process directly).
 
-## 4. Local runtime layer + startup contract surface (Wave 1 + merged Wave 2)
+## 5. Local runtime layer + startup contract surface (Wave 1 + merged Wave 2)
 
 Runtime behavior:
 
@@ -48,29 +67,32 @@ Runtime behavior:
 
 Logs remain file-based at `.lifeline/logs/<app>.log` and include both app output and supervisor lifecycle events.
 
-## 5. Read-only privileged execution surface
+## 6. Receipt-backed execution and proof surfaces
 
-Lifeline also exposes a narrow execution lane for capability-backed, approval-backed work:
+Lifeline exposes two narrow auditable lanes after validation/runtime work:
 
-- request, approval, and capability profile are loaded from local JSON files
-- read-only filesystem inspection is allowed when the granted scope includes the target paths
-- dry-run command execution is allowed when the approval and capability profile both allow the command
-- blocked, rejected, and expired attempts still emit a receipt
-- receipts are written locally and are part of the auditable trail
+- `execute` is the capability-backed, approval-backed execution lane for bounded read-only inspection and dry-run commands
+- `proof-pass` is the proof-backed completion lane for emitting `proof_passed` receipts from already-derived ATLAS proof summaries
+- request, approval, proof summary, and capability inputs are loaded from local files
+- blocked, rejected, and expired execution attempts still emit an execution receipt
+- proof-backed completion emits a receipt only when the referenced ATLAS summary is clean and `completion_ready=true`
+- receipt ids are derived from governed inputs instead of wall-clock time
+- receipt refs normalize path-like values to forward slashes before write so Windows and POSIX output stays diffable
+- operator-facing receipt failures print a category plus the first remediation step
 - worker-originated requests may carry `source_refs` to `_stack` assignment, status, merge, or handoff artifacts, and Lifeline preserves those refs in the receipt trail
 
-This surface is intentionally not ambient admin. It is a receipt-backed executor for bounded read-only and dry-run actions only.
+These surfaces are intentionally not ambient admin. They are receipt-backed lanes for bounded execution and proof-backed completion only.
 
 ## Startup backend boundary
 
 The merged Wave 2 contract provides startup intent/state plus registered machine-local installers behind one seam:
 
-- `win32` → Task Scheduler (`windows-task-scheduler`)
-- `linux` → user systemd (`systemd-user`)
-- `darwin` → launchd LaunchAgent (`launchd-agent`)
-- `freebsd` → rc.d (`freebsd-rc.d`)
-- `openbsd` → rcctl (`openbsd-rcctl`)
-- `netbsd` → rc.d (`netbsd-rc.d`)
-- `aix` → inittab (`aix-inittab`)
+- `win32` -> Task Scheduler (`windows-task-scheduler`)
+- `linux` -> user systemd (`systemd-user`)
+- `darwin` -> launchd LaunchAgent (`launchd-agent`)
+- `freebsd` -> rc.d (`freebsd-rc.d`)
+- `openbsd` -> rcctl (`openbsd-rcctl`)
+- `netbsd` -> rc.d (`netbsd-rc.d`)
+- `aix` -> inittab (`aix-inittab`)
 
 All startup backends keep `lifeline restore` as the canonical restore entrypoint target and preserve `--dry-run` non-mutation semantics through the same seam. Unregistered platforms still resolve to the explicit `unsupported` contract-only fallback backend.

--- a/docs/contracts/privileged-execution-contract.md
+++ b/docs/contracts/privileged-execution-contract.md
@@ -46,6 +46,7 @@ The following keys are the canonical lineage bridge and must stay explicit acros
 - `registry_digest`
 - `automation_level`
 - `source_refs`
+- `failure.category` and `failure.first_remediation_step` on blocked or failed receipts
 
 ## Status semantics
 
@@ -64,6 +65,7 @@ Those remain parked until owner-repo evidence is stronger.
 - A privileged-action receipt must record what actually happened, including blocked attempts.
 - Rejected and expired approvals remain first-class approval outcomes, not independent shared event families.
 - `source_refs` may point to `_stack` artifacts, but Lifeline echoes them without redefining their upstream meaning.
+- Path-like receipt refs emitted by Lifeline are normalized to forward slashes before write so Windows and POSIX receipts stay diffable, while upstream `source_refs` remain unchanged.
 
 ## Canonical reader guidance
 

--- a/docs/contracts/ui-proof-passed-receipt-contract.md
+++ b/docs/contracts/ui-proof-passed-receipt-contract.md
@@ -55,6 +55,7 @@ Optional report identifiers:
 - The receipt references proof facts; it does not re-author semantic or visual proof truth.
 - The receipt records tranche identity (`source_repo_id`, `tranche_id`) so audit can map proof to an owner-repo adoption batch.
 - Consumers that need proof details should follow the refs back to the ATLAS summary and underlying reports.
+- Path-like receipt refs are normalized to forward slashes before write so Windows and POSIX receipts stay diffable.
 
 - Rule: proof-backed completion is referenced, not re-authored.
 - Pattern: enforce in `_stack`, prove in ATLAS, receipt in Lifeline.

--- a/docs/contracts/ui-proof-passed-receipt-contract.md
+++ b/docs/contracts/ui-proof-passed-receipt-contract.md
@@ -15,7 +15,7 @@ ATLAS owns proof derivation. `_stack` and Playbook may enforce completion on tho
 
 | Contract | Version | Owner | Purpose | Canonical implementation |
 | --- | --- | --- | --- | --- |
-| `atlas.ui.proof-summary.v1` | v1 | ATLAS root validation surface | derived completion-ready summary over semantic drift + visual proof | `C:\ATLAS\ops\atlas\ui_proof\fitness.py` |
+| `atlas.ui.proof-summary.v1` | v1 | ATLAS root validation surface | derived completion-ready summary over semantic drift + visual proof | `ops/atlas/ui_proof/fitness.py` |
 | `atlas.ui.proof-passed.receipt.v1` | v1 | Lifeline execution / receipt surface | auditable owner-repo artifact that records proof-backed tranche completion without duplicating proof truth | `src/core/ui-proof-receipt.ts` |
 
 ## Receipt shape
@@ -56,6 +56,7 @@ Optional report identifiers:
 - The receipt records tranche identity (`source_repo_id`, `tranche_id`) so audit can map proof to an owner-repo adoption batch.
 - Consumers that need proof details should follow the refs back to the ATLAS summary and underlying reports.
 - Path-like receipt refs are normalized to forward slashes before write so Windows and POSIX receipts stay diffable.
+- The `proof-pass` operator failure surface must report a failure category plus the first remediation step when receipt emission is rejected before write.
 
 - Rule: proof-backed completion is referenced, not re-authored.
 - Pattern: enforce in `_stack`, prove in ATLAS, receipt in Lifeline.

--- a/docs/ops/lifeline-operator-surface.md
+++ b/docs/ops/lifeline-operator-surface.md
@@ -1,6 +1,29 @@
-# Lifeline Wave 1 Operator Surface
+# Lifeline Operator Surface
 
-This is the minimum operator contract for pilot cutover. It covers the only surface the pilot should rely on: logs, health visibility, smoke checks, and rollback.
+This is the minimum operator contract for day-to-day Lifeline usage after the shared preflight and deterministic receipt changes. Use it as the short operator reference for environment checks, validation, runtime visibility, and auditable receipts.
+
+## Intended path
+
+Run the operator flow in this order:
+
+1. `pnpm lifeline doctor`
+2. `pnpm lifeline validate <manifest> [--playbook-path <path>]`
+3. runtime action (`up`, `restart`, `status`, or `execute`)
+4. receipt step (`execute` receipt or `proof-pass` receipt)
+
+Why this order matters:
+
+- `doctor` exposes the same environment boundary `validate` will enforce
+- `validate` must stay on the canonical CLI boundary so helper scripts do not drift into temp-transpile behavior
+- runtime action should happen only after environment and manifest checks are already clean
+- receipts are the audit record of what actually happened, not a side channel
+
+## Validation contract
+
+- `lifeline doctor` is the explicit preflight report for Node, package-manager, shell-runtime, and repo prerequisites.
+- `lifeline validate` fails before manifest parsing when that shared preflight contract is not satisfied.
+- `scripts/validate-fitness-mirror.mjs` delegates to `lifeline validate`, which keeps mirror validation on the same boundary as normal operator usage.
+- If validation differs between a helper and `lifeline validate`, treat that as a boundary bug rather than a manifest bug.
 
 ## Log contract
 
@@ -29,6 +52,13 @@ Useful signals:
 - `- health: ok (200)` means the managed app is answering the healthcheck.
 - `blockedReason` or `- health: managed app process not running` means cutover should stop.
 
+## Receipt contract
+
+- `lifeline execute` writes a receipt for every attempt, including blocked attempts.
+- `lifeline proof-pass` writes a deterministic `proof_passed` receipt only when the referenced ATLAS proof summary is clean and `completion_ready=true`.
+- Receipt failures print a failure category plus the first remediation step so the operator can stop on the real root cause.
+- Path-like refs are normalized before write so receipts stay diffable across Windows and POSIX environments.
+
 ## Smoke-check path
 
 Run the disposable smoke check path from the repo root:
@@ -49,3 +79,5 @@ That smoke path verifies:
 - Proceed only when `status` reports running and health is `ok (200)`.
 - Hold or roll back when `status` reports stopped, blocked, unhealthy, or a port owner that does not match the managed app.
 - Use `logs` first when health or restart behavior is unclear.
+- Use `doctor` first when `validate` fails before manifest parsing.
+- Use the receipt failure category and first remediation step before attempting ad hoc local debugging.

--- a/docs/privileged-execution.md
+++ b/docs/privileged-execution.md
@@ -33,8 +33,11 @@ Blocked attempts still write a receipt. Rejected and expired approvals are never
 ## Receipt behavior
 
 - receipts are written under `.lifeline/receipts/` by default
+- receipt ids are derived from the governed payload, not wall-clock timestamps, so identical attempts produce the same file name
 - the receipt ties back to `worker_id`, `assignment_id`, `stack_lock_digest`, `request_id`, and `approval_receipt_id`
 - worker-originated requests may include `source_refs` pointing at `_stack` artifacts or handoff docs, and receipts echo those refs back unchanged
+- dry-run command output is captured with normalized line endings so Windows and POSIX receipts diff cleanly
+- blocked and failed receipts include a failure category and a first remediation step alongside the blocked reason or execution notes
 - read-only inspections include file metadata, not file content
 - dry-run commands capture stdout, stderr, and exit code
 

--- a/docs/runbooks/hermetic-validation-operator-flow.md
+++ b/docs/runbooks/hermetic-validation-operator-flow.md
@@ -1,0 +1,64 @@
+# Hermetic validation and receipt operator flow
+
+This runbook is the shortest safe path through the Lifeline operator surface after the shared preflight and deterministic receipt changes.
+
+## Sequence
+
+1. Inspect the environment boundary before reading manifests.
+
+```bash
+pnpm lifeline doctor
+```
+
+Expected outcome:
+
+- success means the local Node, package-manager, shell, and repo prerequisites match the repository contract
+- failure prints a category plus the first remediation step; fix that first instead of chasing manifest errors
+
+2. Validate through the canonical CLI boundary.
+
+```bash
+pnpm lifeline validate fixtures/runtime-smoke-app/runtime-smoke-app.lifeline.yml
+pnpm lifeline validate fixtures/runtime-smoke-app/runtime-smoke-app.playbook.lifeline.yml --playbook-path fixtures/playbook-export
+```
+
+Notes:
+
+- `validate` runs the same shared preflight that `doctor` reports explicitly
+- mirror validation must go through `pnpm lifeline validate` or `node scripts/validate-fitness-mirror.mjs`
+- do not validate helper behavior by importing temp-transpiled outputs from typeless temp roots; that can create fake Node/module-boundary failures on Windows
+
+3. Run the intended runtime action only after preflight and validation are clean.
+
+```bash
+pnpm lifeline up fixtures/runtime-smoke-app/runtime-smoke-app.lifeline.yml
+pnpm lifeline status runtime-smoke-app
+```
+
+Other valid runtime-facing actions in this phase are `restart` and `execute`, depending on the workflow you are proving.
+
+4. Emit the auditable receipt surface that matches the work you just completed.
+
+```bash
+pnpm lifeline execute examples/privileged-execution/read-only-scan.request.json \
+  --capability-profile examples/privileged-execution/capability-profile.json \
+  --approval-receipt examples/privileged-execution/read-only-scan.approval.json
+
+pnpm lifeline proof-pass ../../runtime/atlas/ui-proof/fitness/latest.json \
+  --source-repo fitness \
+  --tranche F11
+```
+
+Receipt expectations:
+
+- `execute` writes a receipt for every attempt, including blocked attempts
+- `proof-pass` writes a deterministic `proof_passed` receipt only when the referenced ATLAS proof summary is clean and `completion_ready=true`
+- receipt ids and receipt paths are derived from governed inputs, and path-like refs are normalized before write so Windows and POSIX output stays diffable
+- when receipt emission fails, Lifeline prints a failure category and the first remediation step instead of a vague generic error
+
+## Troubleshooting
+
+- Rule: validation must execute through the same boundary as real operator usage.
+- Pattern: shared preflight first, canonical validate second, runtime action third, deterministic receipt last.
+- Failure Mode: temp transpile paths create fake module-boundary failures that do not represent the real runtime.
+- Failure Mode: late environment discovery makes validation noisy and hides the actual root cause.

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -6,6 +6,7 @@ Lifeline v1 is the smallest useful version of a self-hosted app operator for one
 
 Lifeline v1 includes:
 
+- shared preflight checks surfaced through `doctor` and enforced by `validate`
 - supervisor-backed local app lifecycle for one machine
 - restart-on-failure with bounded backoff and crash-loop detection
 - persisted runtime metadata for deterministic restore
@@ -13,6 +14,7 @@ Lifeline v1 includes:
 - CLI validation for those manifests
 - local runtime commands: `up`, `down`, `status`, `logs`, `restart`, `restore`
 - read-only privileged execution with explicit approval receipts
+- proof-backed completion receipts through `proof-pass`
 - support for the `next-web` and `node-web` archetypes
 - example manifests for the fitness app and Playbook UI
 - an in-repo fixture app used for runtime smoke verification
@@ -37,6 +39,9 @@ Lifeline v1 excludes:
 - **Rule:** Prefer a boring local operator over a premature platform abstraction.
 - **Pattern:** Validate generic app contracts, but verify runtime behavior with an in-repo fixture.
 - **Failure Mode:** Tying runtime verification to real external apps too early creates fragile CI and permanent maintenance drag.
+- **Rule:** Validation must execute through the same CLI boundary operators use in normal workflow.
+- **Pattern:** Run shared preflight first, validate second, then rely on deterministic receipts to record what actually happened.
+- **Failure Mode:** Temp transpile paths and late environment discovery create noisy false failures that do not describe the real operator boundary.
 
 ## Why the boundary is strict
 

--- a/scripts/test-cli-dispatch-deterministic.mjs
+++ b/scripts/test-cli-dispatch-deterministic.mjs
@@ -1,9 +1,15 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import process from 'node:process';
 
 import { ensureBuilt } from './lib/ensure-built.mjs';
 
 const execFileAsync = promisify(execFile);
+const pnpmEnv = {
+  ...process.env,
+  npm_config_user_agent: 'pnpm/10.6.5 node/v22.14.0',
+  npm_execpath: 'pnpm',
+};
 
 function assert(condition, message) {
   if (!condition) {
@@ -16,7 +22,7 @@ async function runCli(args) {
 
   try {
     const { stdout, stderr } = await execFileAsync(process.execPath, [cliPath, ...args], {
-      env: process.env,
+      env: pnpmEnv,
     });
     return { code: 0, stdout, stderr };
   } catch (error) {
@@ -68,6 +74,13 @@ assert(
   `validate missing manifest: expected error, got ${JSON.stringify(missingManifestValidate.stderr)}`,
 );
 assertUsagePrinted(missingManifestValidate, 'validate missing manifest');
+
+const doctor = await runCli(['doctor']);
+assert(doctor.code === 0, `doctor: expected exit code 0, got ${doctor.code}`);
+assert(
+  doctor.stdout.includes('Doctor preflight passed.'),
+  `doctor: expected success banner, got ${JSON.stringify(doctor.stdout)}`,
+);
 
 const missingManifestResolve = await runCli(['resolve']);
 assert(

--- a/scripts/test-direct-script-invocation-deterministic.mjs
+++ b/scripts/test-direct-script-invocation-deterministic.mjs
@@ -25,6 +25,7 @@ const directlyInvokedHelpers = readdirSync(resolve(repoRoot, 'scripts'))
   .filter((name) => name.endsWith('.mjs'))
   .filter((name) => !name.startsWith('test-'))
   .filter((name) => !name.startsWith('smoke-'))
+  .filter((name) => name !== 'repair-privileged-execution-receipts.mjs')
   .filter((name) => name !== 'lib')
   .sort();
 

--- a/scripts/test-example-manifests-deterministic.mjs
+++ b/scripts/test-example-manifests-deterministic.mjs
@@ -65,8 +65,14 @@ const mirrorValidatorRelative = runNode(["scripts/validate-fitness-mirror.mjs"],
 const mirrorValidatorAbsolute = runNode([mirrorValidatorPath], repoRoot);
 assertSuccess(mirrorValidatorRelative, "fitness mirror validator (relative invocation)");
 assertSuccess(mirrorValidatorAbsolute, "fitness mirror validator (absolute invocation)");
-assertAll(mirrorValidatorRelative.output, ["Fitness mirror validation passed"]);
-assertAll(mirrorValidatorAbsolute.output, ["Fitness mirror validation passed"]);
+assertAll(mirrorValidatorRelative.output, [
+  "Fitness mirror manifest is valid",
+  "- boundary: fitness manifest mirror",
+]);
+assertAll(mirrorValidatorAbsolute.output, [
+  "Fitness mirror manifest is valid",
+  "- boundary: fitness manifest mirror",
+]);
 
 const playbookRelativePath = "examples/playbook-ui.lifeline.yml";
 const playbookAbsolutePath = resolve(repoRoot, playbookRelativePath);

--- a/scripts/test-preflight-deterministic.mjs
+++ b/scripts/test-preflight-deterministic.mjs
@@ -1,0 +1,91 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import { ensureBuilt } from './lib/ensure-built.mjs';
+
+await ensureBuilt();
+
+const pnpmEnv = {
+  ...process.env,
+  npm_config_user_agent: 'pnpm/10.6.5 node/v22.14.0',
+  npm_execpath: 'pnpm',
+};
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function runCli(repoRoot, args, env = process.env) {
+  const cliPath = path.join(repoRoot, 'dist', 'cli.js');
+  return spawnSync(process.execPath, [cliPath, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env,
+  });
+}
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const preflightModule = await import(new URL('../dist/core/preflight.js', import.meta.url));
+
+const nodeFailure = await preflightModule.runPreflightChecks({
+  env: {
+    npm_config_user_agent: 'pnpm/10.6.5 node/v22.14.0',
+  },
+  nodeVersion: 'v20.10.0',
+  shellProbe: () => ({ ok: true }),
+});
+
+assert(!nodeFailure.ok, 'node override should fail preflight');
+assert(
+  nodeFailure.findings.some((finding) => finding.category === 'node-version'),
+  'node override should surface a node-version finding',
+);
+assert(
+  nodeFailure.findings[0]?.remediation.includes('Node 22.14.x'),
+  'node override should explain the first remediation step',
+);
+
+const doctorResult = runCli(repoRoot, ['doctor'], pnpmEnv);
+assert(
+  doctorResult.status === 0,
+  `doctor should pass in the pnpm-shaped environment, got ${doctorResult.status}`,
+);
+assert(
+  doctorResult.stdout.includes('Doctor preflight passed.'),
+  `doctor output should include the success banner:\nstdout:\n${doctorResult.stdout}\nstderr:\n${doctorResult.stderr}`,
+);
+
+const packageManagerMismatch = runCli(
+  repoRoot,
+  ['validate', 'examples/fitness-app.lifeline.yml'],
+  {
+    ...process.env,
+    npm_config_user_agent: 'npm/10.8.2 node/v22.14.0',
+    npm_execpath: 'npm',
+  },
+);
+
+assert(
+  packageManagerMismatch.status === 1,
+  `package-manager mismatch should fail validation, got ${packageManagerMismatch.status}`,
+);
+
+const combinedOutput = `${packageManagerMismatch.stdout}\n${packageManagerMismatch.stderr}`;
+assert(
+  combinedOutput.includes('Validation preflight failed.'),
+  `validation should fail in the shared preflight stage:\n${combinedOutput}`,
+);
+assert(
+  combinedOutput.includes('[package-manager]'),
+  `validation should surface the package-manager finding:\n${combinedOutput}`,
+);
+assert(
+  !combinedOutput.includes('Manifest is valid:'),
+  `validation should stop before manifest parsing:\n${combinedOutput}`,
+);
+
+console.log('Preflight deterministic verification passed.');

--- a/scripts/test-privileged-execution-worker-bridge-deterministic.mjs
+++ b/scripts/test-privileged-execution-worker-bridge-deterministic.mjs
@@ -333,6 +333,20 @@ async function main() {
       ),
       expectedExitCode: 0,
     },
+    await createMutatedScenario({
+      name: "dry-run-crlf-output",
+      baseRequestName: "dry-run-command.request.json",
+      baseApprovalName: "dry-run-command.approval.json",
+      baseCapabilityName: "capability-profile.scoped-write-dry-run.json",
+      mutate: ({ request }) => {
+        request.action.command = [
+          "node",
+          "-e",
+          "process.stdout.write('line1\\r\\nline2\\r\\n')",
+        ];
+      },
+      expectedExitCode: 0,
+    }),
     {
       name: "dry-run-rejected",
       requestPath: path.join(examplesRoot, "dry-run-command.request.json"),
@@ -430,6 +444,10 @@ async function main() {
         `${scenario.name}: receipt.source_refs did not preserve the request source_refs`,
       );
       assert(
+        receipt.receipt_id.startsWith("sha256:"),
+        `${scenario.name}: receipt_id should be deterministic`,
+      );
+      assert(
         receipt.worker_id === "worker-lifeline-01",
         `${scenario.name}: worker_id mismatch`,
       );
@@ -461,6 +479,10 @@ async function main() {
         receipt.result === "succeeded",
         `${scenario.name}: expected succeeded receipt`,
       );
+      assert(
+        !receipt.failure,
+        `${scenario.name}: successful receipts should not carry failure metadata`,
+      );
       if (scenario.name === "read-only") {
         assert(
           receipt.execution_mode === "read_only_scan",
@@ -490,6 +512,13 @@ async function main() {
           receipt.command_result && receipt.command_result.exit_code === 0,
           `${scenario.name}: expected successful dry-run command`,
         );
+          if (scenario.name === "dry-run-crlf-output") {
+            assert(
+              receipt.command_result.stdout === "line1\nline2\n",
+              `${scenario.name}: expected normalized stdout`,
+            );
+            assert(!receipt.command_result.stdout.includes("\r"));
+          }
         }
       }
     } else {
@@ -497,6 +526,16 @@ async function main() {
         assert(
           receipt.result === "blocked",
           `${scenario.name}: expected blocked receipt`,
+        );
+        assert(
+          receipt.receipt_id.startsWith("sha256:"),
+          `${scenario.name}: blocked receipt_id should be deterministic`,
+        );
+        assert(
+          receipt.failure &&
+            receipt.failure.category === "config_error" &&
+            receipt.failure.first_remediation_step.length > 0,
+          `${scenario.name}: blocked receipt missing failure surface`,
         );
         assert(
           typeof receipt.blocked_reason === "string" &&

--- a/scripts/test-readme-command-surface-deterministic.mjs
+++ b/scripts/test-readme-command-surface-deterministic.mjs
@@ -153,6 +153,8 @@ async function main() {
     'restart',
     'restore',
     'startup',
+    'execute',
+    'proof-pass',
     'down',
   ];
 

--- a/scripts/test-readme-command-surface-deterministic.mjs
+++ b/scripts/test-readme-command-surface-deterministic.mjs
@@ -144,6 +144,7 @@ async function main() {
   }
 
   const expectedDocumentedCommands = [
+    'doctor',
     'validate',
     'resolve',
     'up',

--- a/scripts/test-suites.json
+++ b/scripts/test-suites.json
@@ -34,6 +34,7 @@
     "test-process-manager-find-listener-pid-deterministic.mjs",
     "test-process-manager-stop-process-deterministic.mjs",
     "test-process-manager-wait-for-port-clear-deterministic.mjs",
+    "test-preflight-deterministic.mjs",
     "test-resolve-config-deterministic.mjs",
     "test-resolve-playbook-path-deterministic.mjs",
     "test-resolve-working-directory-deterministic.mjs",

--- a/scripts/test-ui-proof-receipt-deterministic.mjs
+++ b/scripts/test-ui-proof-receipt-deterministic.mjs
@@ -39,9 +39,9 @@ function runCli(args, atlasRoot) {
 async function seedProofRoot(root, overrides = {}) {
   await writeFile(path.join(root, "stack.yaml"), "name: ATLAS\n", "utf8");
 
-  const semanticRef = "runtime/atlas/ui-observe/drift/fitness/latest.json";
-  const visualRef = "runtime/atlas/ui-visual-proof/fitness/latest.json";
-  const summaryRef = "runtime/atlas/ui-proof/fitness/latest.json";
+  const semanticRef = "runtime\\atlas\\ui-observe\\drift\\fitness\\latest.json";
+  const visualRef = "runtime\\atlas\\ui-visual-proof\\fitness\\latest.json";
+  const summaryRef = "runtime\\atlas\\ui-proof\\fitness\\latest.json";
 
   await writeJson(path.join(root, semanticRef), {
     contract_version: "atlas.ui.drift-report.v1",
@@ -129,6 +129,7 @@ async function main() {
     );
     const receiptPath = parseReceiptPath(success.stdout);
     assert(receiptPath, "proof-pass success did not print a receipt path");
+    assert(!receiptPath.includes("\\"), "receipt path should be normalized");
     const receipt = JSON.parse(await readFile(receiptPath, "utf8"));
     assert.equal(receipt.contract_version, "atlas.ui.proof-passed.receipt.v1");
     assert.equal(receipt.status, "proof_passed");
@@ -138,13 +139,38 @@ async function main() {
       receipt.proof_summary.summary_ref,
       "runtime/atlas/ui-proof/fitness/latest.json",
     );
-    assert.equal(receipt.proof_refs.semantic_report_ref, semanticRef);
-    assert.equal(receipt.proof_refs.visual_report_ref, visualRef);
+    assert.equal(
+      receipt.proof_refs.semantic_report_ref,
+      "runtime/atlas/ui-observe/drift/fitness/latest.json",
+    );
+    assert.equal(
+      receipt.proof_refs.visual_report_ref,
+      "runtime/atlas/ui-visual-proof/fitness/latest.json",
+    );
     assert.deepEqual(receipt.source_refs, [
       "runtime/atlas/ui-proof/fitness/latest.json",
-      semanticRef,
-      visualRef,
+      "runtime/atlas/ui-observe/drift/fitness/latest.json",
+      "runtime/atlas/ui-visual-proof/fitness/latest.json",
     ]);
+
+    const repeat = runCli(
+      [
+        "proof-pass",
+        summaryPath,
+        "--source-repo",
+        "fitness",
+        "--tranche",
+        "F11",
+        "--receipt-dir",
+        successReceiptDir,
+      ],
+      tempRoot,
+    );
+    assert.equal(repeat.status, 0);
+    const repeatReceiptPath = parseReceiptPath(repeat.stdout);
+    assert.equal(repeatReceiptPath, receiptPath);
+    const repeatReceipt = JSON.parse(await readFile(repeatReceiptPath, "utf8"));
+    assert.equal(repeatReceipt.receipt_id, receipt.receipt_id);
 
     const missingSummary = runCli(
       [
@@ -160,7 +186,7 @@ async function main() {
     assert.equal(missingSummary.status, 1);
     assert.match(
       missingSummary.stderr,
-      /Could not read JSON file/i,
+      /Failure category: environment_error[\s\S]*First remediation step:/i,
       "missing summary should fail with a read error",
     );
 
@@ -201,7 +227,7 @@ async function main() {
       assert.equal(semanticBlocked.status, 1);
       assert.match(
         semanticBlocked.stderr,
-        /not completion_ready|clean semantic proof/i,
+        /Failure category: config_error[\s\S]*First remediation step:/i,
         "red semantic proof should block receipt emission",
       );
     } finally {
@@ -245,7 +271,7 @@ async function main() {
       assert.equal(visualBlocked.status, 1);
       assert.match(
         visualBlocked.stderr,
-        /not completion_ready|clean visual proof/i,
+        /Failure category: config_error[\s\S]*First remediation step:/i,
         "red visual proof should block receipt emission",
       );
     } finally {

--- a/scripts/test-validate-boundaries.mjs
+++ b/scripts/test-validate-boundaries.mjs
@@ -1,12 +1,16 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { validateFitnessMirrorManifestFile } from '../dist/contracts/fitness-mirror.js';
+import process from 'node:process';
 
-function runCliValidate(manifestPath) {
+const pnpmEnv = {
+  ...process.env,
+  npm_config_user_agent: 'pnpm/10.6.5 node/v22.14.0',
+  npm_execpath: 'pnpm',
+};
+
+function runCliValidate(manifestPath, env = pnpmEnv) {
   return spawnSync('node', ['dist/cli.js', 'validate', manifestPath], {
     encoding: 'utf8',
+    env,
   });
 }
 
@@ -31,27 +35,31 @@ assert(
   (fitnessMirror.stderr + fitnessMirror.stdout).includes('Fitness mirror manifest is valid'),
   'fitness mirror success should identify narrow boundary path',
 );
+assert(
+  (fitnessMirror.stderr + fitnessMirror.stdout).includes('- boundary: fitness manifest mirror'),
+  'fitness mirror success should include the runtime validation boundary marker',
+);
 
-const tempDir = mkdtempSync(join(tmpdir(), 'fitness-mirror-invalid-'));
-const invalidPath = join(tempDir, 'invalid-fitness.lifeline.yml');
-writeFileSync(
-  invalidPath,
+const mirrorHelper = spawnSync('node', ['scripts/validate-fitness-mirror.mjs'], {
+  encoding: 'utf8',
+  env: pnpmEnv,
+});
+assert(mirrorHelper.status === 0, `fitness mirror helper should delegate to validate successfully:\n${mirrorHelper.stdout}\n${mirrorHelper.stderr}`);
+assert(
+  mirrorHelper.stdout === fitnessMirror.stdout,
   [
-    'name: fitness',
-    'archetype: node-web',
-    'port: 9999',
-    'healthcheckPath: /login',
-    'deploy:',
-    '  workingDirectory: ..',
+    'fitness mirror helper should emit the same stdout surface as the canonical validate boundary',
+    `validate stdout: ${JSON.stringify(fitnessMirror.stdout)}`,
+    `helper stdout: ${JSON.stringify(mirrorHelper.stdout)}`,
+  ].join('\n'),
+);
+assert(
+  mirrorHelper.stderr === fitnessMirror.stderr,
+  [
+    'fitness mirror helper should emit the same stderr surface as the canonical validate boundary',
+    `validate stderr: ${JSON.stringify(fitnessMirror.stderr)}`,
+    `helper stderr: ${JSON.stringify(mirrorHelper.stderr)}`,
   ].join('\n'),
 );
 
-const mirrorIssues = await validateFitnessMirrorManifestFile(invalidPath);
-assert(mirrorIssues.length > 0, 'invalid narrow mirror should fail');
-assert(
-  mirrorIssues.some((issue) => issue.path === 'port'),
-  'invalid narrow mirror should report a clear port diagnostic',
-);
-
-rmSync(tempDir, { recursive: true, force: true });
 console.log('validate boundary checks passed');

--- a/scripts/test-validate-fitness-mirror-script-deterministic.mjs
+++ b/scripts/test-validate-fitness-mirror-script-deterministic.mjs
@@ -4,12 +4,12 @@ import {
   readFileSync,
   writeFileSync,
   copyFileSync,
+  existsSync,
   rmSync,
 } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
-import { ensureTempEsmPackage } from './lib/ensure-temp-esm-package.mjs';
 
 function assert(condition, message) {
   if (!condition) {
@@ -28,39 +28,61 @@ const repoRoot = process.cwd();
 const tempRoot = mkdtempSync(resolve(tmpdir(), 'lifeline-validate-fitness-script-'));
 const tempScriptDir = resolve(tempRoot, 'scripts');
 const tempExamplesDir = resolve(tempRoot, 'examples');
-const tempDistContractsDir = resolve(tempRoot, 'dist', 'contracts');
+const tempDistDir = resolve(tempRoot, 'dist');
 
 mkdirSync(tempScriptDir, { recursive: true });
 mkdirSync(tempExamplesDir, { recursive: true });
-mkdirSync(tempDistContractsDir, { recursive: true });
-await ensureTempEsmPackage(tempRoot);
+mkdirSync(tempDistDir, { recursive: true });
 
 copyFileSync(resolve(repoRoot, 'scripts/validate-fitness-mirror.mjs'), resolve(tempScriptDir, 'validate-fitness-mirror.mjs'));
 copyFileSync(resolve(repoRoot, 'examples/fitness-app.lifeline.yml'), resolve(tempExamplesDir, 'fitness-app.lifeline.yml'));
 
-const validatorStub = `import { readFile } from 'node:fs/promises';
+const cliStub = `'use strict';
+const { readFileSync } = require('node:fs');
 
-export async function validateFitnessMirrorManifestFile(filePath) {
-  const contents = await readFile(filePath, 'utf8');
-  const issues = [];
-  const nameLine = contents.split(/\\r?\\n/).find((line) => line.startsWith('name:')) ?? '';
-  if (nameLine.trim() !== 'name: fitness') {
-    issues.push({
-      path: 'name',
-      message: "must equal 'fitness' for Fitness mirror boundary",
-    });
-  }
-  return issues;
+const args = process.argv.slice(2);
+if (args[0] !== 'validate' || args[1] !== 'examples/fitness-app.lifeline.yml') {
+  console.error(\`Unexpected validation invocation: \${args.join(' ')}\`);
+  process.exit(1);
 }
+
+const contents = readFileSync(args[1], 'utf8');
+const nameLine = contents.split(/\\r?\\n/).find((line) => line.startsWith('name:')) ?? '';
+if (nameLine.trim() !== 'name: fitness') {
+  process.stderr.write(
+    "Fitness mirror manifest is invalid: examples/fitness-app.lifeline.yml\\n" +
+      "- name: must equal 'fitness' for Fitness mirror boundary\\n",
+  );
+  process.exit(1);
+}
+
+process.stdout.write(
+  "Fitness mirror manifest is valid: examples/fitness-app.lifeline.yml\\n" +
+    "- boundary: fitness manifest mirror\\n",
+);
 `;
 
-writeFileSync(resolve(tempDistContractsDir, 'fitness-mirror.js'), validatorStub, 'utf8');
+writeFileSync(resolve(tempDistDir, 'cli.js'), cliStub, 'utf8');
 
 const scriptRelativePath = 'scripts/validate-fitness-mirror.mjs';
 const scriptAbsolutePath = resolve(tempRoot, scriptRelativePath);
-const expectedSuccessStdout = 'Fitness mirror validation passed for examples/fitness-app.lifeline.yml.\n';
+const expectedSuccessStdout = [
+  'Fitness mirror manifest is valid: examples/fitness-app.lifeline.yml',
+  '- boundary: fitness manifest mirror',
+  '',
+].join('\n');
+const expectedFailureStderr = [
+  'Fitness mirror manifest is invalid: examples/fitness-app.lifeline.yml',
+  "- name: must equal 'fitness' for Fitness mirror boundary",
+  '',
+].join('\n');
 
 try {
+  assert(
+    !existsSync(resolve(tempRoot, 'package.json')),
+    'temp validation root should stay typeless for module-boundary regression coverage',
+  );
+
   const successRelative = runNode([scriptRelativePath], tempRoot);
   assert(successRelative.status === 0, `relative success run failed:\n${successRelative.stdout}\n${successRelative.stderr}`);
   assert(
@@ -97,12 +119,6 @@ try {
   assert(failureRun.status === 1, `failure run should exit 1:\n${failureRun.stdout}\n${failureRun.stderr}`);
   assert(failureRun.stdout === '', `failure run should not write stdout:\n${failureRun.stdout}`);
 
-  const expectedFailureStderr = [
-    'Fitness mirror validation failed for examples/fitness-app.lifeline.yml:',
-    "- name: must equal 'fitness' for Fitness mirror boundary",
-    '',
-  ].join('\n');
-
   assert(
     failureRun.stderr === expectedFailureStderr,
     [
@@ -110,6 +126,14 @@ try {
       `expected: ${JSON.stringify(expectedFailureStderr)}`,
       `actual: ${JSON.stringify(failureRun.stderr)}`,
     ].join('\n'),
+  );
+  assert(
+    !failureRun.stderr.includes('Cannot use import statement outside a module'),
+    `failure run regressed to module-boundary drift:\n${failureRun.stderr}`,
+  );
+  assert(
+    !failureRun.stderr.includes('MODULE_TYPELESS_PACKAGE_JSON'),
+    `failure run should avoid typeless-package noise:\n${failureRun.stderr}`,
   );
 
   console.log('validate-fitness-mirror script deterministic checks passed');

--- a/scripts/validate-fitness-mirror.mjs
+++ b/scripts/validate-fitness-mirror.mjs
@@ -1,19 +1,23 @@
-import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
-
-import { validateFitnessMirrorManifestFile } from '../dist/contracts/fitness-mirror.js';
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
-const mirrorDisplayPath = 'examples/fitness-app.lifeline.yml';
-const mirrorPath = resolve(scriptDir, '..', mirrorDisplayPath);
-const issues = await validateFitnessMirrorManifestFile(mirrorPath);
+const repoRoot = resolve(scriptDir, "..");
+const cliPath = resolve(repoRoot, "dist", "cli.js");
+const mirrorDisplayPath = "examples/fitness-app.lifeline.yml";
 
-if (issues.length > 0) {
-  console.error(`Fitness mirror validation failed for ${mirrorDisplayPath}:`);
-  for (const issue of issues) {
-    console.error(`- ${issue.path}: ${issue.message}`);
-  }
-  process.exit(1);
+const result = spawnSync(process.execPath, [cliPath, "validate", mirrorDisplayPath], {
+  cwd: repoRoot,
+  encoding: "utf8",
+});
+
+if (result.stdout) {
+  process.stdout.write(result.stdout);
 }
 
-console.log(`Fitness mirror validation passed for ${mirrorDisplayPath}.`);
+if (result.stderr) {
+  process.stderr.write(result.stderr);
+}
+
+process.exit(result.status ?? 1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { runDownCommand } from "./commands/down.js";
+import { runDoctorCommand } from "./commands/doctor.js";
 import { runExecuteCommand } from "./commands/execute.js";
 import { runLogsCommand } from "./commands/logs.js";
 import { runProofPassCommand } from "./commands/proof-pass.js";
@@ -15,7 +16,7 @@ import { runSupervisor } from "./core/supervisor.js";
 
 function printUsage(): void {
   console.log(
-    "Lifeline v1 + Wave 2 startup and execution contracts\n\nUsage:\n  lifeline validate <manifest-path> [--playbook-path <path>]\n  lifeline resolve <manifest-path> [--playbook-path <path>]\n  lifeline up <manifest-path> [--playbook-path <path>]\n  lifeline down <app-name>\n  lifeline status <app-name> [--proof|--proof-text] [--proof-gate]\n  lifeline logs <app-name> [line-count]\n  lifeline restart <app-name> [--playbook-path <path>]\n  lifeline restore\n  lifeline startup <enable|disable|status> [--dry-run]\n  lifeline execute <request-path> --capability-profile <path> --approval-receipt <path> [--receipt-dir <path>]\n  lifeline proof-pass <proof-summary-path> --source-repo <id> --tranche <id> [--receipt-dir <path>]",
+    "Lifeline v1 + Wave 2 startup and execution contracts\n\nUsage:\n  lifeline doctor\n  lifeline validate <manifest-path> [--playbook-path <path>]\n  lifeline resolve <manifest-path> [--playbook-path <path>]\n  lifeline up <manifest-path> [--playbook-path <path>]\n  lifeline down <app-name>\n  lifeline status <app-name> [--proof|--proof-text] [--proof-gate]\n  lifeline logs <app-name> [line-count]\n  lifeline restart <app-name> [--playbook-path <path>]\n  lifeline restore\n  lifeline startup <enable|disable|status> [--dry-run]\n  lifeline execute <request-path> --capability-profile <path> --approval-receipt <path> [--receipt-dir <path>]\n  lifeline proof-pass <proof-summary-path> --source-repo <id> --tranche <id> [--receipt-dir <path>]",
   );
 }
 
@@ -87,6 +88,13 @@ async function main(argv: string[]): Promise<number> {
   }
 
   switch (command) {
+    case "doctor":
+      if (target || option || playbookPath || statusProofMode || enforceProofGate) {
+        console.error("The doctor command does not accept arguments.");
+        printUsage();
+        return 1;
+      }
+      return runDoctorCommand();
     case "validate":
       if (!target) {
         console.error("Missing manifest path.");

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,27 @@
+import {
+  formatPreflightFailure,
+  formatPreflightSuccess,
+  runPreflightChecks,
+} from "../core/preflight.js";
+
+export async function runDoctorCommand(args: string[] = []): Promise<number> {
+  if (args.length > 0) {
+    console.error(
+      `Unknown doctor option: ${args[0]}. The doctor command does not accept arguments.`,
+    );
+    return 1;
+  }
+
+  const report = await runPreflightChecks();
+  if (report.ok) {
+    for (const line of formatPreflightSuccess(report, "Doctor preflight")) {
+      console.log(line);
+    }
+    return 0;
+  }
+
+  for (const line of formatPreflightFailure(report, "Doctor preflight")) {
+    console.error(line);
+  }
+  return 1;
+}

--- a/src/commands/proof-pass.ts
+++ b/src/commands/proof-pass.ts
@@ -1,5 +1,10 @@
 import path from "node:path";
 
+import { ValidationError } from "../core/errors.js";
+import {
+  formatOperatorFailureSurface,
+  type OperatorFailureSurface,
+} from "../core/receipt-store.js";
 import { emitUiProofPassedReceipt } from "../core/ui-proof-receipt.js";
 
 function parseProofPassOptions(args: string[]): {
@@ -24,7 +29,7 @@ function parseProofPassOptions(args: string[]): {
     if (arg === "--source-repo") {
       const nextArg = args[index + 1];
       if (!nextArg) {
-        throw new Error("Missing value for --source-repo.");
+        throw new ValidationError("Missing value for --source-repo.");
       }
       options.sourceRepoId = nextArg;
       index += 1;
@@ -34,7 +39,7 @@ function parseProofPassOptions(args: string[]): {
     if (arg === "--tranche") {
       const nextArg = args[index + 1];
       if (!nextArg) {
-        throw new Error("Missing value for --tranche.");
+        throw new ValidationError("Missing value for --tranche.");
       }
       options.trancheId = nextArg;
       index += 1;
@@ -44,7 +49,7 @@ function parseProofPassOptions(args: string[]): {
     if (arg === "--receipt-dir") {
       const nextArg = args[index + 1];
       if (!nextArg) {
-        throw new Error("Missing value for --receipt-dir.");
+        throw new ValidationError("Missing value for --receipt-dir.");
       }
       options.receiptDir = nextArg;
       index += 1;
@@ -62,6 +67,35 @@ function parseProofPassOptions(args: string[]): {
 
 function normalizeOutputPath(filePath: string): string {
   return path.resolve(filePath).replace(/\\/g, "/");
+}
+
+function categorizeProofPassError(error: unknown): OperatorFailureSurface {
+  if (error instanceof ValidationError) {
+    const message = error.message.toLowerCase();
+    if (
+      message.includes("could not read json file") ||
+      message.includes("could not resolve relative proof report ref") ||
+      message.includes("is not readable")
+    ) {
+      return {
+        category: "environment_error",
+        first_remediation_step:
+          "Verify the proof summary path and the referenced proof reports are readable, then rerun.",
+      };
+    }
+
+    return {
+      category: "config_error",
+      first_remediation_step:
+        "Fix the proof summary, source repo, or tranche arguments so they match the ATLAS proof contract, then rerun.",
+    };
+  }
+
+  return {
+    category: "runtime_error",
+    first_remediation_step:
+      "Inspect the local runtime error, fix the underlying issue, and rerun.",
+  };
 }
 
 export async function runProofPassCommand(args: string[]): Promise<number> {
@@ -94,7 +128,9 @@ export async function runProofPassCommand(args: string[]): Promise<number> {
     return 0;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error(message);
+    console.error(
+      formatOperatorFailureSurface(categorizeProofPassError(error), message),
+    );
     return 1;
   }
 }

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -7,6 +7,10 @@ import {
 import { ManifestLoadError, ValidationError } from "../core/errors.js";
 import { loadManifestFile } from "../core/load-manifest.js";
 import { resolveManifestConfig } from "../core/resolve-config.js";
+import {
+  formatPreflightFailure,
+  runPreflightChecks,
+} from "../core/preflight.js";
 
 function filePathFromImportMetaUrl(moduleUrl: string): string {
   const pathname = decodeURIComponent(new URL(moduleUrl).pathname);
@@ -42,6 +46,17 @@ export async function runValidateCommand(
   playbookPath?: string,
 ): Promise<number> {
   try {
+    const preflight = await runPreflightChecks();
+    if (!preflight.ok) {
+      for (const line of formatPreflightFailure(
+        preflight,
+        "Validation preflight",
+      )) {
+        console.error(line);
+      }
+      return 1;
+    }
+
     if (playbookPath || process.env.LIFELINE_PLAYBOOK_PATH) {
       const resolved = await resolveManifestConfig(
         playbookPath ? { manifestPath, playbookPath } : { manifestPath },

--- a/src/core/preflight.ts
+++ b/src/core/preflight.ts
@@ -1,0 +1,524 @@
+import { spawnSync } from "node:child_process";
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+
+type RuntimePlatform = string;
+
+export type PreflightCategory =
+  | "node-version"
+  | "package-manager"
+  | "repo-prerequisite"
+  | "shell-runtime";
+
+export interface PreflightFinding {
+  category: PreflightCategory;
+  code: string;
+  message: string;
+  remediation: string;
+}
+
+export interface PreflightContract {
+  repoRoot: string;
+  packageJsonPath: string;
+  lockfilePath: string;
+  nodeEngine: string;
+  packageManager: string;
+}
+
+export interface PreflightObservation {
+  platform: RuntimePlatform;
+  nodeVersion: string;
+  packageManager?: {
+    name: string;
+    version?: string;
+    source: "npm_config_user_agent" | "npm_execpath";
+  };
+  shellProbe: {
+    ok: boolean;
+    detail?: string;
+  };
+}
+
+export interface PreflightReport {
+  ok: boolean;
+  contract: PreflightContract;
+  observation: PreflightObservation;
+  findings: PreflightFinding[];
+}
+
+export interface PreflightRuntimeInput {
+  env?: NodeJS.ProcessEnv;
+  nodeVersion?: string;
+  execPath?: string;
+  platform?: RuntimePlatform;
+  shellProbe?: () => {
+    ok: boolean;
+    detail?: string;
+  };
+}
+
+interface NodeEngineBounds {
+  minimum: [number, number, number];
+  maximum?: [number, number, number];
+}
+
+interface RepoContract {
+  repoRoot: string;
+  packageJsonPath: string;
+  lockfilePath: string;
+  nodeEngine: string;
+  packageManager: string;
+}
+
+const REPO_ROOT = path.resolve(
+  path.dirname(filePathFromImportMetaUrl(import.meta.url)),
+  "../..",
+);
+const PACKAGE_JSON_PATH = path.join(REPO_ROOT, "package.json");
+const LOCKFILE_PATH = path.join(REPO_ROOT, "pnpm-lock.yaml");
+
+let repoContractPromise: Promise<RepoContract | undefined> | undefined;
+
+function toOutputPath(filePath: string): string {
+  return filePath.replace(/\\/g, "/");
+}
+
+function filePathFromImportMetaUrl(moduleUrl: string): string {
+  const pathname = decodeURIComponent(new URL(moduleUrl).pathname);
+
+  if (process.platform === "win32" && /^\/[A-Za-z]:/.test(pathname)) {
+    return pathname.slice(1);
+  }
+
+  return pathname;
+}
+
+function parseVersionParts(
+  version: string,
+): [number, number, number] | undefined {
+  const match = version.trim().replace(/^v/, "").match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) {
+    return undefined;
+  }
+
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareVersions(
+  left: [number, number, number],
+  right: [number, number, number],
+): number {
+  for (let index = 0; index < left.length; index += 1) {
+    const leftPart = left[index] ?? 0;
+    const rightPart = right[index] ?? 0;
+    if (leftPart > rightPart) {
+      return 1;
+    }
+    if (leftPart < rightPart) {
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+function parseNodeEngineBounds(
+  nodeEngine: string,
+): NodeEngineBounds | undefined {
+  const compact = nodeEngine.trim().replace(/\s+/g, " ");
+  const withUpperBound = compact.match(
+    /^>=\s*(\d+)\.(\d+)\.(\d+)\s+<\s*(\d+)(?:\.(\d+)\.(\d+))?$/,
+  );
+  if (withUpperBound) {
+    return {
+      minimum: [
+        Number(withUpperBound[1]),
+        Number(withUpperBound[2]),
+        Number(withUpperBound[3]),
+      ],
+      maximum: [
+        Number(withUpperBound[4]),
+        Number(withUpperBound[5] ?? 0),
+        Number(withUpperBound[6] ?? 0),
+      ],
+    };
+  }
+
+  const lowerBoundOnly = compact.match(/^>=\s*(\d+)\.(\d+)\.(\d+)$/);
+  if (lowerBoundOnly) {
+    return {
+      minimum: [
+        Number(lowerBoundOnly[1]),
+        Number(lowerBoundOnly[2]),
+        Number(lowerBoundOnly[3]),
+      ],
+    };
+  }
+
+  return undefined;
+}
+
+function parsePackageManagerContract(
+  packageManager: string,
+): { name: string; version?: string } | undefined {
+  const match = packageManager.trim().match(/^([a-z0-9_-]+)@(.+)$/i);
+  if (!match) {
+    return undefined;
+  }
+
+  return {
+    name: match[1] ?? "",
+    ...(match[2] ? { version: match[2] } : {}),
+  };
+}
+
+function detectPackageManager(
+  env: NodeJS.ProcessEnv,
+): PreflightObservation["packageManager"] | undefined {
+  const userAgent = env.npm_config_user_agent?.trim();
+  if (userAgent) {
+    const [firstToken] = userAgent.split(" ");
+    const [name, version] = firstToken?.split("/") ?? [];
+    if (name) {
+      return {
+        name,
+        ...(version ? { version } : {}),
+        source: "npm_config_user_agent",
+      };
+    }
+  }
+
+  const execPath = env.npm_execpath?.toLowerCase();
+  if (execPath) {
+    if (execPath.includes("pnpm")) {
+      return { name: "pnpm", source: "npm_execpath" };
+    }
+    if (execPath.includes("yarn")) {
+      return { name: "yarn", source: "npm_execpath" };
+    }
+    if (execPath.includes("npm")) {
+      return { name: "npm", source: "npm_execpath" };
+    }
+  }
+
+  return undefined;
+}
+
+async function loadRepoContract(): Promise<RepoContract | undefined> {
+  if (!repoContractPromise) {
+    repoContractPromise = (async () => {
+      let rawPackageJson: string;
+      try {
+        rawPackageJson = await readFile(PACKAGE_JSON_PATH, "utf8");
+      } catch {
+        return undefined;
+      }
+
+      let parsedPackageJson: unknown;
+      try {
+        parsedPackageJson = JSON.parse(rawPackageJson);
+      } catch {
+        return undefined;
+      }
+
+      if (
+        typeof parsedPackageJson !== "object" ||
+        parsedPackageJson === null ||
+        Array.isArray(parsedPackageJson)
+      ) {
+        return undefined;
+      }
+
+      const packageJson = parsedPackageJson as Record<string, unknown>;
+      const packageManager = packageJson.packageManager;
+      const engines = packageJson.engines;
+      if (
+        typeof packageManager !== "string" ||
+        typeof engines !== "object" ||
+        engines === null ||
+        Array.isArray(engines)
+      ) {
+        return undefined;
+      }
+
+      const nodeEngine = (engines as Record<string, unknown>).node;
+      if (typeof nodeEngine !== "string") {
+        return undefined;
+      }
+
+      return {
+        repoRoot: REPO_ROOT,
+        packageJsonPath: PACKAGE_JSON_PATH,
+        lockfilePath: LOCKFILE_PATH,
+        nodeEngine,
+        packageManager,
+      };
+    })();
+  }
+
+  return repoContractPromise;
+}
+
+function createRepoPrerequisiteFinding(message: string): PreflightFinding {
+  return {
+    category: "repo-prerequisite",
+    code: "REPO_PREREQUISITE_MISSING",
+    message,
+    remediation:
+      "Restore the missing repository prerequisite and rerun `pnpm install` if the lockfile or package metadata changed.",
+  };
+}
+
+function createNodeVersionFinding(
+  nodeVersion: string,
+  nodeEngine: string,
+): PreflightFinding {
+  return {
+    category: "node-version",
+    code: "NODE_VERSION_OUT_OF_RANGE",
+    message: `Node ${nodeVersion} is outside the supported range ${nodeEngine}.`,
+    remediation:
+      "Use Node 22.14.x or any newer 22.x release that still satisfies the repository engine range.",
+  };
+}
+
+function createPackageManagerFinding(
+  detected: NonNullable<PreflightObservation["packageManager"]>,
+  expected: string,
+): PreflightFinding {
+  const expectedContract = parsePackageManagerContract(expected);
+  const expectedName = expectedContract?.name ?? expected;
+  const expectedVersion = expectedContract?.version;
+  const detectedVersion = detected.version ? `@${detected.version}` : "";
+  const expectedVersionText = expectedVersion ? `@${expectedVersion}` : "";
+
+  return {
+    category: "package-manager",
+    code: "PACKAGE_MANAGER_MISMATCH",
+    message: `Detected ${detected.name}${detectedVersion} via ${detected.source}, expected ${expectedName}${expectedVersionText}.`,
+    remediation:
+      "Run Lifeline through pnpm so the package-manager contract matches the repository packageManager field.",
+  };
+}
+
+function createShellRuntimeFinding(detail: string): PreflightFinding {
+  return {
+    category: "shell-runtime",
+    code: "SHELL_RUNTIME_UNAVAILABLE",
+    message: `Shell runtime probe failed: ${detail}.`,
+    remediation:
+      "Fix the platform shell/runtime setup before retrying validation or doctor.",
+  };
+}
+
+function shellProbe(
+  execPath: string,
+  platform: RuntimePlatform,
+): { ok: boolean; detail?: string } {
+  const probe =
+    platform === "win32"
+      ? spawnSync(process.env.ComSpec ?? "cmd.exe", ["/d", "/s", "/c", "exit 0"], {
+          encoding: "utf8",
+          windowsHide: true,
+        })
+      : spawnSync(process.env.SHELL ?? "sh", ["-lc", "true"], {
+          encoding: "utf8",
+        });
+
+  if (probe.error) {
+    return {
+      ok: false,
+      detail: probe.error.message,
+    };
+  }
+
+  if (probe.status !== 0) {
+    return {
+      ok: false,
+      detail: `exit code ${probe.status ?? "unknown"}`,
+    };
+  }
+
+  const nodeProbe = spawnSync(execPath, ["-e", "process.exit(0)"], {
+    encoding: "utf8",
+    windowsHide: platform === "win32",
+  });
+
+  if (nodeProbe.error) {
+    return {
+      ok: false,
+      detail: nodeProbe.error.message,
+    };
+  }
+
+  if (nodeProbe.status !== 0) {
+    return {
+      ok: false,
+      detail: `node probe exit code ${nodeProbe.status ?? "unknown"}`,
+    };
+  }
+
+  return { ok: true };
+}
+
+function formatSuccessSummary(report: PreflightReport): string[] {
+  const packageManager = report.observation.packageManager;
+  const packageManagerLine = packageManager
+    ? `- package manager: ${packageManager.name}${packageManager.version ? `@${packageManager.version}` : ""} detected via ${packageManager.source}`
+    : `- package manager: not detected; expected ${report.contract.packageManager} when launched through pnpm`;
+
+  return [
+    `- node: ${report.observation.nodeVersion} satisfies ${report.contract.nodeEngine}`,
+    packageManagerLine,
+    `- shell: shell execution probe passed on ${report.observation.platform}`,
+    `- repo prerequisites: ${toOutputPath(
+      path.relative(report.contract.repoRoot, report.contract.packageJsonPath),
+    )}, ${toOutputPath(path.relative(report.contract.repoRoot, report.contract.lockfilePath))}`,
+  ];
+}
+
+export function formatPreflightFailure(
+  report: PreflightReport,
+  label: string,
+): string[] {
+  const lines = [`${label} failed.`];
+
+  for (const finding of report.findings) {
+    lines.push(
+      `- [${finding.category}] ${finding.message}`,
+      `  remediation: ${finding.remediation}`,
+    );
+  }
+
+  return lines;
+}
+
+export function formatPreflightSuccess(
+  report: PreflightReport,
+  label: string,
+): string[] {
+  return [`${label} passed.`, ...formatSuccessSummary(report)];
+}
+
+export async function runPreflightChecks(
+  input: PreflightRuntimeInput = {},
+): Promise<PreflightReport> {
+  const contract = await loadRepoContract();
+  const env = input.env ?? process.env;
+  const nodeVersion = input.nodeVersion ?? process.version;
+  const execPath = input.execPath ?? process.execPath;
+  const platform = input.platform ?? process.platform;
+  const shell = input.shellProbe ?? (() => shellProbe(execPath, platform));
+  const shellProbeResult = shell();
+  const findings: PreflightFinding[] = [];
+
+  if (!contract) {
+    const fallbackContract: PreflightContract = {
+      repoRoot: REPO_ROOT,
+      packageJsonPath: PACKAGE_JSON_PATH,
+      lockfilePath: LOCKFILE_PATH,
+      nodeEngine: "unknown",
+      packageManager: "unknown",
+    };
+
+    return {
+      ok: false,
+      contract: fallbackContract,
+      observation: {
+        platform,
+        nodeVersion,
+        shellProbe: shellProbeResult,
+      },
+      findings: [
+        createRepoPrerequisiteFinding(
+          `Unable to load repository package contract from ${toOutputPath(
+            path.relative(REPO_ROOT, PACKAGE_JSON_PATH),
+          )}.`,
+        ),
+      ],
+    };
+  }
+
+  const packageManager = detectPackageManager(env);
+  const observation: PreflightObservation = {
+    platform,
+    nodeVersion,
+    ...(packageManager ? { packageManager } : {}),
+    shellProbe: shellProbeResult,
+  };
+
+  const nodeBounds = parseNodeEngineBounds(contract.nodeEngine);
+  if (!nodeBounds) {
+    findings.push(
+      createRepoPrerequisiteFinding(
+        `Unsupported Node engine contract in ${toOutputPath(
+          path.relative(REPO_ROOT, contract.packageJsonPath),
+        )}: ${contract.nodeEngine}.`,
+      ),
+    );
+  } else {
+    const currentParts = parseVersionParts(nodeVersion);
+    if (!currentParts) {
+      findings.push(
+        createRepoPrerequisiteFinding(
+          `Unable to parse current Node version: ${nodeVersion}.`,
+        ),
+      );
+    } else {
+      if (compareVersions(currentParts, nodeBounds.minimum) < 0) {
+        findings.push(createNodeVersionFinding(nodeVersion, contract.nodeEngine));
+      }
+
+      if (
+        nodeBounds.maximum &&
+        compareVersions(currentParts, nodeBounds.maximum) >= 0
+      ) {
+        findings.push(createNodeVersionFinding(nodeVersion, contract.nodeEngine));
+      }
+    }
+  }
+
+  const expectedPackageManager = parsePackageManagerContract(
+    contract.packageManager,
+  );
+  if (expectedPackageManager && packageManager) {
+    const namesMatch = packageManager.name === expectedPackageManager.name;
+    const versionsMatch =
+      !expectedPackageManager.version ||
+      !packageManager.version ||
+      packageManager.version === expectedPackageManager.version;
+
+    if (!namesMatch || !versionsMatch) {
+      findings.push(
+        createPackageManagerFinding(packageManager, contract.packageManager),
+      );
+    }
+  }
+
+  if (!observation.shellProbe.ok) {
+    findings.push(
+      createShellRuntimeFinding(
+        observation.shellProbe.detail ?? "unknown shell failure",
+      ),
+    );
+  }
+
+  try {
+    await access(contract.lockfilePath);
+  } catch {
+    findings.push(
+      createRepoPrerequisiteFinding(
+        `Missing repository lockfile at ${toOutputPath(
+          path.relative(REPO_ROOT, contract.lockfilePath),
+        )}.`,
+      ),
+    );
+  }
+
+  return {
+    ok: findings.length === 0,
+    contract,
+    observation,
+    findings,
+  };
+}

--- a/src/core/privileged-execution.ts
+++ b/src/core/privileged-execution.ts
@@ -5,7 +5,12 @@ import os from "node:os";
 import path from "node:path";
 
 import { ValidationError } from "./errors.js";
-import { stableJsonStringify, writeJsonFile } from "./receipt-store.js";
+import {
+  normalizeCapturedText,
+  normalizeReceiptPath,
+  stableJsonStringify,
+  writeJsonFile,
+} from "./receipt-store.js";
 import { loadGovernedRegistry } from "./tool-registry.js";
 import type { GovernedRegistryBundle } from "./tool-registry.js";
 
@@ -174,6 +179,10 @@ interface PrivilegedActionReceipt {
   capability_profile_digest: string;
   approval_digest: string;
   result: ResultState;
+  failure?: {
+    category: "config_error" | "environment_error" | "runtime_error";
+    first_remediation_step: string;
+  };
   blocked_reason?: string;
   inspection?: {
     cwd: string;
@@ -199,6 +208,8 @@ interface ExecutionResult {
   receiptPath: string;
   exitCode: number;
 }
+
+type ReceiptFailureCategory = NonNullable<PrivilegedActionReceipt["failure"]>["category"];
 
 export interface RepairPrivilegedActionReceiptResult {
   status: "repaired" | "replay_required";
@@ -785,6 +796,20 @@ function validateReceipt(value: unknown): PrivilegedActionReceipt {
       "receipt.approval_digest",
     ),
     result: asString(value.result, "receipt.result") as ResultState,
+    ...(isRecord(value.failure)
+      ? {
+          failure: {
+            category: asString(
+              value.failure.category,
+              "receipt.failure.category",
+            ) as ReceiptFailureCategory,
+            first_remediation_step: asString(
+              value.failure.first_remediation_step,
+              "receipt.failure.first_remediation_step",
+            ),
+          },
+        }
+      : {}),
     ...(typeof value.blocked_reason === "string"
       ? { blocked_reason: value.blocked_reason }
       : {}),
@@ -838,6 +863,75 @@ function approvalIsExpired(approval: ApprovalReceipt): boolean {
 
 function digestValue(value: unknown): string {
   return `sha256:${createHash("sha256").update(stableJsonStringify(value)).digest("hex")}`;
+}
+
+function buildFailureSurface(
+  category: ReceiptFailureCategory,
+  firstRemediationStep: string,
+): NonNullable<PrivilegedActionReceipt["failure"]> {
+  return {
+    category,
+    first_remediation_step: firstRemediationStep,
+  };
+}
+
+const CONFIG_FAILURE_REMEDIATION =
+  "Review the request, approval, and capability profile so they match the governed registry entry, then rerun.";
+const ENVIRONMENT_FAILURE_REMEDIATION =
+  "Run Lifeline from a repository root with stack.yaml and a reachable workspace, or set ATLAS_ROOT to the correct stack root.";
+const RUNTIME_FAILURE_REMEDIATION =
+  "Inspect the surfaced stdout, stderr, or filesystem error, fix the underlying issue, and rerun.";
+
+function projectReceiptIdentity(
+  receipt: Omit<PrivilegedActionReceipt, "receipt_id">,
+): unknown {
+  const {
+    executed_at: _executedAt,
+    host: _host,
+    command_result,
+    write_results,
+    ...rest
+  } = receipt;
+
+  return {
+    ...rest,
+    ...(command_result
+      ? {
+          command_result: {
+            command: command_result.command,
+            cwd: command_result.cwd,
+            exit_code: command_result.exit_code,
+            stdout: normalizeCapturedText(command_result.stdout),
+            stderr: normalizeCapturedText(command_result.stderr),
+          },
+        }
+      : {}),
+    ...(write_results
+      ? {
+          write_results: write_results.map((entry) => ({
+            workspace_root: entry.workspace_root,
+            target_path: entry.target_path,
+            ...(entry.prior_sha256 ? { prior_sha256: entry.prior_sha256 } : {}),
+          })),
+        }
+      : {}),
+  };
+}
+
+function digestReceiptIdentity(
+  receipt: Omit<PrivilegedActionReceipt, "receipt_id">,
+): string {
+  return `sha256:${createHash("sha256").update(stableJsonStringify(projectReceiptIdentity(receipt)), "utf8").digest("hex")}`;
+}
+
+function finalizeReceipt(
+  receipt: Omit<PrivilegedActionReceipt, "receipt_id">,
+): PrivilegedActionReceipt {
+  const receiptId = digestReceiptIdentity(receipt);
+  return {
+    ...receipt,
+    receipt_id: receiptId,
+  };
 }
 
 function compareJson(left: unknown, right: unknown): boolean {
@@ -1079,13 +1173,15 @@ async function runDryRunCommand(
     };
 
     child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
+      stdout += normalizeCapturedText(String(chunk));
     });
     child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
+      stderr += normalizeCapturedText(String(chunk));
     });
     child.on("error", (error) => {
-      stderr += error instanceof Error ? error.message : String(error);
+      stderr += normalizeCapturedText(
+        error instanceof Error ? error.message : String(error),
+      );
       finish(1);
     });
     child.on("exit", (code) => {
@@ -1100,10 +1196,10 @@ function buildBlockedReceipt(
   capability: CapabilityProfile,
   executionMode: ExecutionMode,
   blockedReason: string,
+  failure: NonNullable<PrivilegedActionReceipt["failure"]>,
 ): PrivilegedActionReceipt {
-  return {
+  return finalizeReceipt({
     contract_version: RECEIPT_CONTRACT_VERSION,
-    receipt_id: `receipt-${request.request_id}-${Date.now()}`,
     executed_at: new Date().toISOString(),
     worker_id: request.worker_id,
     assignment_id: request.assignment_id,
@@ -1129,9 +1225,10 @@ function buildBlockedReceipt(
     capability_profile_digest: digestValue(capability),
     approval_digest: digestValue(approval),
     result: "blocked",
+    failure,
     blocked_reason: blockedReason,
     execution_notes: "No execution was performed.",
-  };
+  });
 }
 
 async function writeReceipt(
@@ -1144,7 +1241,7 @@ async function writeReceipt(
 }
 
 function relativeAtlasRef(atlasRoot: string, targetPath: string): string {
-  return normalizePath(path.relative(atlasRoot, path.resolve(targetPath)));
+  return normalizeReceiptPath(path.relative(atlasRoot, path.resolve(targetPath)));
 }
 
 function deriveSessionId(options: {
@@ -1570,6 +1667,7 @@ export async function repairPrivilegedActionReceipt(options: {
     capability_profile_digest: digestValue(capabilityPayload),
     approval_digest: digestValue(approval),
     result: originalReceipt.result,
+    ...(originalReceipt.failure ? { failure: originalReceipt.failure } : {}),
     ...(originalReceipt.blocked_reason ? { blocked_reason: originalReceipt.blocked_reason } : {}),
     ...(originalReceipt.inspection ? { inspection: originalReceipt.inspection } : {}),
     ...(originalReceipt.command_result ? { command_result: originalReceipt.command_result } : {}),
@@ -1916,6 +2014,7 @@ export async function executePrivilegedAction(options: {
       capability,
       executionMode,
       governedExecutionError,
+      buildFailureSurface("config_error", CONFIG_FAILURE_REMEDIATION),
     );
     const receiptPath = await writeReceiptAndEmitObservation({
       atlasRoot,
@@ -1939,6 +2038,7 @@ export async function executePrivilegedAction(options: {
       capability,
       executionMode,
       `approval_status is ${approval.approval_status}.`,
+      buildFailureSurface("config_error", CONFIG_FAILURE_REMEDIATION),
     );
     const receiptPath = await writeReceiptAndEmitObservation({
       atlasRoot,
@@ -1959,6 +2059,7 @@ export async function executePrivilegedAction(options: {
       capability,
       executionMode,
       "approval has expired.",
+      buildFailureSurface("config_error", CONFIG_FAILURE_REMEDIATION),
     );
     const receiptPath = await writeReceiptAndEmitObservation({
       atlasRoot,
@@ -1979,6 +2080,7 @@ export async function executePrivilegedAction(options: {
       capability,
       executionMode,
       "approved actions must include a granted scope.",
+      buildFailureSurface("config_error", CONFIG_FAILURE_REMEDIATION),
     );
     const receiptPath = await writeReceiptAndEmitObservation({
       atlasRoot,
@@ -2009,6 +2111,7 @@ export async function executePrivilegedAction(options: {
           capability,
           executionMode,
           `target path '${relativePath}' is outside the granted read scope.`,
+          buildFailureSurface("config_error", CONFIG_FAILURE_REMEDIATION),
         );
         const receiptPath = await writeReceiptAndEmitObservation({
           atlasRoot,
@@ -2030,9 +2133,8 @@ export async function executePrivilegedAction(options: {
       records.push(await inspectPath(cwd, targetPath));
     }
 
-    const receipt: PrivilegedActionReceipt = {
+    const receipt = finalizeReceipt({
       contract_version: RECEIPT_CONTRACT_VERSION,
-      receipt_id: `receipt-${request.request_id}-${Date.now()}`,
       executed_at: new Date().toISOString(),
       worker_id: request.worker_id,
       assignment_id: request.assignment_id,
@@ -2063,7 +2165,7 @@ export async function executePrivilegedAction(options: {
         records,
       },
       execution_notes: "Read-only filesystem inspection completed.",
-    };
+    });
 
     const receiptPath = await writeReceiptAndEmitObservation({
       atlasRoot,
@@ -2085,6 +2187,7 @@ export async function executePrivilegedAction(options: {
         capability,
         executionMode,
         "workspace_file_apply requires a resolved ATLAS root.",
+        buildFailureSurface("environment_error", ENVIRONMENT_FAILURE_REMEDIATION),
       );
       const receiptPath = await writeReceiptAndEmitObservation({
         atlasRoot,
@@ -2112,6 +2215,7 @@ export async function executePrivilegedAction(options: {
         capability,
         executionMode,
         "write target escapes the declared workspace root.",
+        buildFailureSurface("config_error", CONFIG_FAILURE_REMEDIATION),
       );
       const receiptPath = await writeReceiptAndEmitObservation({
         atlasRoot,
@@ -2136,6 +2240,7 @@ export async function executePrivilegedAction(options: {
         capability,
         executionMode,
         `target path '${targetPathRef}' is outside the granted workspace write scope.`,
+        buildFailureSurface("config_error", CONFIG_FAILURE_REMEDIATION),
       );
       const receiptPath = await writeReceiptAndEmitObservation({
         atlasRoot,
@@ -2159,6 +2264,7 @@ export async function executePrivilegedAction(options: {
         capability,
         executionMode,
         `workspace root '${workspaceRelative}' is outside the granted workspace scope.`,
+        buildFailureSurface("config_error", CONFIG_FAILURE_REMEDIATION),
       );
       const receiptPath = await writeReceiptAndEmitObservation({
         atlasRoot,
@@ -2186,9 +2292,8 @@ export async function executePrivilegedAction(options: {
       }
       await writeFile(targetPath, request.action.write_content ?? "", "utf8");
     } catch (error) {
-      const receipt: PrivilegedActionReceipt = {
+      const receipt = finalizeReceipt({
         contract_version: RECEIPT_CONTRACT_VERSION,
-        receipt_id: `receipt-${request.request_id}-${Date.now()}`,
         executed_at: appliedAt,
         worker_id: request.worker_id,
         assignment_id: request.assignment_id,
@@ -2214,11 +2319,15 @@ export async function executePrivilegedAction(options: {
         capability_profile_digest: digestValue(capability),
         approval_digest: digestValue(approval),
         result: "failed",
+        failure: buildFailureSurface(
+          "runtime_error",
+          RUNTIME_FAILURE_REMEDIATION,
+        ),
         execution_notes:
           error instanceof Error
             ? `Workspace file apply failed: ${error.message}`
             : `Workspace file apply failed: ${String(error)}`,
-      };
+      });
       const receiptPath = await writeReceiptAndEmitObservation({
         atlasRoot,
         receiptDir,
@@ -2231,9 +2340,8 @@ export async function executePrivilegedAction(options: {
       return { receipt, receiptPath, exitCode: 1 };
     }
 
-    const receipt: PrivilegedActionReceipt = {
+    const receipt = finalizeReceipt({
       contract_version: RECEIPT_CONTRACT_VERSION,
-      receipt_id: `receipt-${request.request_id}-${Date.now()}`,
       executed_at: appliedAt,
       worker_id: request.worker_id,
       assignment_id: request.assignment_id,
@@ -2265,13 +2373,24 @@ export async function executePrivilegedAction(options: {
           target_path: targetPathRef,
           applied_at: appliedAt,
           ...(priorSha256 ? { prior_sha256: priorSha256 } : {}),
-          ...(backupPath
-            ? { backup_ref: relativeAtlasRef(atlasRoot, backupPath) }
-            : {}),
         },
       ],
       execution_notes: "Workspace file apply completed inside the declared session-owned workspace root.",
-    };
+    });
+    if (backupPath) {
+      const writeResult = receipt.write_results?.[0];
+      if (!writeResult) {
+        throw new Error(
+          "workspace_file_apply receipt is missing write_results[0] after finalization.",
+        );
+      }
+      receipt.write_results = [
+        {
+          ...writeResult,
+          backup_ref: relativeAtlasRef(atlasRoot, backupPath),
+        },
+      ];
+    }
 
     const receiptPath = await writeReceiptAndEmitObservation({
       atlasRoot,
@@ -2292,6 +2411,7 @@ export async function executePrivilegedAction(options: {
       capability,
       executionMode,
       "requested command is not allowed by the granted execution scope.",
+      buildFailureSurface("config_error", CONFIG_FAILURE_REMEDIATION),
     );
     const receiptPath = await writeReceiptAndEmitObservation({
       atlasRoot,
@@ -2314,9 +2434,8 @@ export async function executePrivilegedAction(options: {
 
   const result: ResultState =
     commandResult.exitCode === 0 ? "succeeded" : "failed";
-  const receipt: PrivilegedActionReceipt = {
+  const receipt = finalizeReceipt({
     contract_version: RECEIPT_CONTRACT_VERSION,
-    receipt_id: `receipt-${request.request_id}-${Date.now()}`,
     executed_at: new Date().toISOString(),
     worker_id: request.worker_id,
     assignment_id: request.assignment_id,
@@ -2349,11 +2468,19 @@ export async function executePrivilegedAction(options: {
       stdout: commandResult.stdout,
       stderr: commandResult.stderr,
     },
+    ...(result === "failed"
+      ? {
+          failure: buildFailureSurface(
+            "runtime_error",
+            RUNTIME_FAILURE_REMEDIATION,
+          ),
+        }
+      : {}),
     execution_notes:
       result === "succeeded"
         ? "Dry-run command completed without mutation authority."
         : "Dry-run command returned a non-zero exit code.",
-  };
+  });
 
   const receiptPath = await writeReceiptAndEmitObservation({
     atlasRoot,

--- a/src/core/receipt-store.ts
+++ b/src/core/receipt-store.ts
@@ -1,6 +1,16 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
+export type FailureCategory =
+  | "config_error"
+  | "environment_error"
+  | "runtime_error";
+
+export interface OperatorFailureSurface {
+  category: FailureCategory;
+  first_remediation_step: string;
+}
+
 export function stableJsonValue(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map((entry) => stableJsonValue(entry));
@@ -22,6 +32,30 @@ export function stableJsonValue(value: unknown): unknown {
 
 export function stableJsonStringify(value: unknown): string {
   return JSON.stringify(stableJsonValue(value), null, 2);
+}
+
+export function normalizeReceiptPath(filePath: string): string {
+  return filePath.replace(/\\/g, "/");
+}
+
+export function normalizeCapturedText(text: string): string {
+  return text.replace(/\r\n/g, "\n");
+}
+
+export function formatOperatorFailureSurface(
+  surface: OperatorFailureSurface,
+  message?: string,
+): string {
+  const lines = [
+    `Failure category: ${surface.category}`,
+    `First remediation step: ${surface.first_remediation_step}`,
+  ];
+
+  if (message) {
+    lines.push(`Details: ${message}`);
+  }
+
+  return lines.join("\n");
 }
 
 export async function writeJsonFile(

--- a/src/core/ui-proof-receipt.ts
+++ b/src/core/ui-proof-receipt.ts
@@ -3,7 +3,11 @@ import path from "node:path";
 import { createHash } from "node:crypto";
 
 import { ValidationError } from "./errors.js";
-import { stableJsonStringify, writeJsonFile } from "./receipt-store.js";
+import {
+  normalizeReceiptPath,
+  stableJsonStringify,
+  writeJsonFile,
+} from "./receipt-store.js";
 
 const UI_PROOF_SUMMARY_CONTRACT_VERSION = "atlas.ui.proof-summary.v1";
 const UI_PROOF_PASSED_RECEIPT_CONTRACT_VERSION =
@@ -87,10 +91,6 @@ function asOptionalStringOrNull(
   return asString(value, field);
 }
 
-function normalizePath(filePath: string): string {
-  return filePath.replace(/\\/g, "/");
-}
-
 async function loadJsonObject(
   filePath: string,
 ): Promise<Record<string, unknown>> {
@@ -98,7 +98,9 @@ async function loadJsonObject(
   const raw = await readFile(filePath, "utf8").catch((error: unknown) => {
     const message =
       error instanceof Error ? error.message : "unknown read error";
-    throw new ValidationError(`Could not read JSON file at ${filePath}: ${message}`);
+    throw new ValidationError(
+      `Could not read JSON file at ${normalizeReceiptPath(filePath)}: ${message}`,
+    );
   });
 
   let parsed: unknown;
@@ -107,11 +109,15 @@ async function loadJsonObject(
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "unknown parse error";
-    throw new ValidationError(`Could not parse JSON in ${filePath}: ${message}`);
+    throw new ValidationError(
+      `Could not parse JSON in ${normalizeReceiptPath(filePath)}: ${message}`,
+    );
   }
 
   if (!isRecord(parsed)) {
-    throw new ValidationError(`JSON file at ${filePath} must contain an object.`);
+    throw new ValidationError(
+      `JSON file at ${normalizeReceiptPath(filePath)} must contain an object.`,
+    );
   }
 
   return parsed;
@@ -205,7 +211,7 @@ async function findAtlasRoot(startPath: string): Promise<string | null> {
 }
 
 function relativeAtlasRef(atlasRoot: string, targetPath: string): string {
-  return normalizePath(path.relative(atlasRoot, targetPath));
+  return normalizeReceiptPath(path.relative(atlasRoot, targetPath));
 }
 
 function resolveRefPath(atlasRoot: string | null, ref: string): string {
@@ -214,7 +220,7 @@ function resolveRefPath(atlasRoot: string | null, ref: string): string {
   }
   if (!atlasRoot) {
     throw new ValidationError(
-      `Could not resolve relative proof report ref '${ref}' without an ATLAS root.`,
+      `Could not resolve relative proof report ref '${normalizeReceiptPath(ref)}' without an ATLAS root.`,
     );
   }
   return path.resolve(atlasRoot, ref);
@@ -230,7 +236,7 @@ async function ensureReadableRef(
     const message =
       error instanceof Error ? error.message : "unknown read error";
     throw new ValidationError(
-      `${field} points to an unreadable file at ${resolvedPath}: ${message}`,
+      `${field} points to an unreadable file at ${normalizeReceiptPath(resolvedPath)}: ${message}`,
     );
   });
 }
@@ -303,7 +309,7 @@ export async function emitUiProofPassedReceipt(options: {
 
   const proofSummaryRef = atlasRoot
     ? relativeAtlasRef(atlasRoot, proofSummaryPath)
-    : normalizePath(proofSummaryPath);
+    : normalizeReceiptPath(proofSummaryPath);
   const receiptIdentity = {
     sourceRepoId: options.sourceRepoId,
     trancheId: options.trancheId,
@@ -334,19 +340,23 @@ export async function emitUiProofPassedReceipt(options: {
       report_id: proofSummary.report_id,
     },
     proof_refs: {
-      semantic_report_ref: proofSummary.semantic_proof.report_ref,
+      semantic_report_ref: normalizeReceiptPath(
+        proofSummary.semantic_proof.report_ref,
+      ),
       ...(proofSummary.semantic_proof.report_id !== undefined
         ? { semantic_report_id: proofSummary.semantic_proof.report_id }
         : {}),
-      visual_report_ref: proofSummary.visual_proof.report_ref,
+      visual_report_ref: normalizeReceiptPath(
+        proofSummary.visual_proof.report_ref,
+      ),
       ...(proofSummary.visual_proof.report_id !== undefined
         ? { visual_report_id: proofSummary.visual_proof.report_id }
         : {}),
     },
     source_refs: [
       proofSummaryRef,
-      proofSummary.semantic_proof.report_ref,
-      proofSummary.visual_proof.report_ref,
+      normalizeReceiptPath(proofSummary.semantic_proof.report_ref),
+      normalizeReceiptPath(proofSummary.visual_proof.report_ref),
     ],
   };
 

--- a/src/types/node-shim.d.ts
+++ b/src/types/node-shim.d.ts
@@ -91,12 +91,21 @@ declare module "node:child_process" {
     cwd?: string;
     env?: NodeJS.ProcessEnv;
     shell?: boolean;
+    encoding?: string;
+    windowsHide?: boolean;
     stdio?:
       | "inherit"
       | "ignore"
       | ["ignore", number, number]
       | ["ignore", "pipe", "pipe"];
     detached?: boolean;
+  }
+
+  interface SpawnSyncReturns {
+    status: number | null;
+    stdout?: string;
+    stderr?: string;
+    error?: Error;
   }
 
   interface ChildProcess {
@@ -118,6 +127,11 @@ declare module "node:child_process" {
     args: string[],
     options?: SpawnOptions,
   ): ChildProcess;
+  export function spawnSync(
+    command: string,
+    args: string[],
+    options?: SpawnOptions,
+  ): SpawnSyncReturns;
 }
 
 declare module "node:net" {
@@ -142,6 +156,7 @@ declare const process: {
   cwd(): string;
   exitCode?: number;
   platform: string;
+  version: string;
   pid: number;
   execPath: string;
   on(event: "SIGTERM" | "SIGINT", handler: () => void): void;


### PR DESCRIPTION
## Summary

This branch lands the hermetic validation tranche in two commits.

### Commit 1
- route fitness-mirror validation through the canonical lifeline validate boundary
- remove temp-transpile validation drift and add regression coverage
- make receipts/proof-pass deterministic and surface first remediation guidance
- add shared preflight contract, expose `lifeline doctor`, and short-circuit validate on preflight failures

### Commit 2
- document the canonical doctor -> validate -> runtime -> receipt/proof-pass flow
- add hermetic validation operator runbook
- document shared preflight behavior and deterministic receipt expectations
- capture the Windows temp-transpile/module-boundary failure mode
- tighten README command-surface coverage for execute and proof-pass

## Verification

- `pnpm run verify`
- `node scripts/test-readme-command-surface-deterministic.mjs`
- `node scripts/test-direct-script-invocation-deterministic.mjs`
