### PR TITLE
Lifeline: expand proof-pass and preflight fixture coverage

### DIFF
--- a/docs/PLAYBOOK_NOTES.md
+++ b/docs/PLAYBOOK_NOTES.md
@@ -19,6 +19,20 @@ Link related pull requests whenever possible.
 - Failure mode addressed:
   - Temp transpile paths and late environment discovery can create noisy module-boundary failures that do not match the real Lifeline boundary.
 
+## 2026-04-22
+
+- WHAT changed:
+  - Expanded deterministic preflight rejection fixtures across `node-version`, `package-manager`, `shell-runtime`, and `repo-prerequisite` classifications.
+  - Expanded `proof-pass` deterministic fixtures for unreadable proof refs, malformed summaries, owner mismatches, blocked proof states, and Windows-oriented path canonicalization.
+  - Canonicalized ATLAS-internal absolute proof refs to stack-relative forward-slash refs before proof-passed receipt write.
+- WHY it changed:
+  - Failure categories and first-remediation guidance need direct fixture coverage so proof/operator surfaces stay stable instead of drifting with ad hoc stderr text.
+  - Windows and mixed-path runs should emit the same proof receipt refs as POSIX runs at the artifact boundary.
+- Pattern:
+  - Fixture-back failure categories and normalize path refs at receipt emission, not only at display time.
+- Failure mode addressed:
+  - Proof receipts could preserve machine-local absolute Windows report paths even when the reports were inside the ATLAS root, making artifacts less canonical and less diffable.
+
 ## 2026-03-25
 
 - WHAT changed:

--- a/docs/contracts/ui-proof-passed-receipt-contract.md
+++ b/docs/contracts/ui-proof-passed-receipt-contract.md
@@ -56,6 +56,7 @@ Optional report identifiers:
 - The receipt records tranche identity (`source_repo_id`, `tranche_id`) so audit can map proof to an owner-repo adoption batch.
 - Consumers that need proof details should follow the refs back to the ATLAS summary and underlying reports.
 - Path-like receipt refs are normalized to forward slashes before write so Windows and POSIX receipts stay diffable.
+- ATLAS-internal absolute proof refs are rewritten to stack-relative refs before write so emitted receipts stay canonical across machines.
 - The `proof-pass` operator failure surface must report a failure category plus the first remediation step when receipt emission is rejected before write.
 
 - Rule: proof-backed completion is referenced, not re-authored.

--- a/scripts/test-preflight-deterministic.mjs
+++ b/scripts/test-preflight-deterministic.mjs
@@ -31,23 +31,104 @@ function runCli(repoRoot, args, env = process.env) {
 const repoRoot = fileURLToPath(new URL('..', import.meta.url));
 const preflightModule = await import(new URL('../dist/core/preflight.js', import.meta.url));
 
-const nodeFailure = await preflightModule.runPreflightChecks({
-  env: {
-    npm_config_user_agent: 'pnpm/10.6.5 node/v22.14.0',
+const rejectionFixtures = [
+  {
+    name: 'node-version',
+    input: {
+      env: pnpmEnv,
+      nodeVersion: 'v20.10.0',
+      shellProbe: () => ({ ok: true }),
+    },
+    expected: {
+      category: 'node-version',
+      code: 'NODE_VERSION_OUT_OF_RANGE',
+      messageIncludes: 'outside the supported range',
+      remediationIncludes: 'Node 22.14.x',
+    },
   },
-  nodeVersion: 'v20.10.0',
-  shellProbe: () => ({ ok: true }),
-});
+  {
+    name: 'package-manager',
+    input: {
+      env: {
+        ...process.env,
+        npm_config_user_agent: 'npm/10.8.2 node/v22.14.0',
+        npm_execpath: 'npm',
+      },
+      nodeVersion: 'v22.14.0',
+      shellProbe: () => ({ ok: true }),
+    },
+    expected: {
+      category: 'package-manager',
+      code: 'PACKAGE_MANAGER_MISMATCH',
+      messageIncludes: 'Detected npm@10.8.2',
+      remediationIncludes: 'Run Lifeline through pnpm',
+    },
+  },
+  {
+    name: 'shell-runtime',
+    input: {
+      env: pnpmEnv,
+      nodeVersion: 'v22.14.0',
+      shellProbe: () => ({ ok: false, detail: 'cmd.exe unavailable' }),
+    },
+    expected: {
+      category: 'shell-runtime',
+      code: 'SHELL_RUNTIME_UNAVAILABLE',
+      messageIncludes: 'cmd.exe unavailable',
+      remediationIncludes: 'Fix the platform shell/runtime setup',
+    },
+  },
+  {
+    name: 'repo-prerequisite',
+    input: {
+      env: pnpmEnv,
+      nodeVersion: 'not-a-semver',
+      shellProbe: () => ({ ok: true }),
+    },
+    expected: {
+      category: 'repo-prerequisite',
+      code: 'REPO_PREREQUISITE_MISSING',
+      messageIncludes: 'Unable to parse current Node version',
+      remediationIncludes: 'Restore the missing repository prerequisite',
+    },
+  },
+];
 
-assert(!nodeFailure.ok, 'node override should fail preflight');
-assert(
-  nodeFailure.findings.some((finding) => finding.category === 'node-version'),
-  'node override should surface a node-version finding',
-);
-assert(
-  nodeFailure.findings[0]?.remediation.includes('Node 22.14.x'),
-  'node override should explain the first remediation step',
-);
+for (const fixture of rejectionFixtures) {
+  const report = await preflightModule.runPreflightChecks(fixture.input);
+  assert(!report.ok, `${fixture.name} fixture should fail preflight`);
+  assert(
+    report.findings.length === 1,
+    `${fixture.name} fixture should surface exactly one finding, got ${report.findings.length}`,
+  );
+  assert(
+    report.findings[0]?.category === fixture.expected.category,
+    `${fixture.name} fixture should classify as ${fixture.expected.category}, got ${report.findings[0]?.category}`,
+  );
+  assert(
+    report.findings[0]?.code === fixture.expected.code,
+    `${fixture.name} fixture should use code ${fixture.expected.code}, got ${report.findings[0]?.code}`,
+  );
+  assert(
+    report.findings[0]?.message.includes(fixture.expected.messageIncludes),
+    `${fixture.name} fixture should mention ${fixture.expected.messageIncludes}:\n${report.findings[0]?.message}`,
+  );
+  assert(
+    report.findings[0]?.remediation.includes(fixture.expected.remediationIncludes),
+    `${fixture.name} fixture should explain remediation ${fixture.expected.remediationIncludes}:\n${report.findings[0]?.remediation}`,
+  );
+
+  const failureLines = preflightModule.formatPreflightFailure(report, 'Preflight');
+  const failureSurface = failureLines.join('\n');
+  assert(
+    failureSurface.includes(`[${fixture.expected.category}]`),
+    `${fixture.name} failure surface should include the category banner:\n${failureSurface}`,
+  );
+  assert(
+    failureSurface.includes(`remediation: ${report.findings[0]?.remediation}`),
+    `${fixture.name} failure surface should include the remediation line:\n${failureSurface}`,
+  );
+}
 
 const doctorResult = runCli(repoRoot, ['doctor'], pnpmEnv);
 assert(
@@ -82,6 +163,10 @@ assert(
 assert(
   combinedOutput.includes('[package-manager]'),
   `validation should surface the package-manager finding:\n${combinedOutput}`,
+);
+assert(
+  combinedOutput.includes('remediation: Run Lifeline through pnpm'),
+  `validation should preserve the package-manager remediation text:\n${combinedOutput}`,
 );
 assert(
   !combinedOutput.includes('Manifest is valid:'),

--- a/scripts/test-ui-proof-receipt-deterministic.mjs
+++ b/scripts/test-ui-proof-receipt-deterministic.mjs
@@ -14,9 +14,17 @@ async function writeJson(filePath, payload) {
   await writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
 }
 
+function resolveFixturePath(root, fileRef) {
+  return path.isAbsolute(fileRef) ? fileRef : path.join(root, fileRef);
+}
+
 function parseReceiptPath(stdout) {
   const match = stdout.match(/Receipt written:\s*(.+)\s*$/m);
   return match ? match[1].trim() : null;
+}
+
+function normalizePath(value) {
+  return value.replaceAll("\\", "/");
 }
 
 function runCli(args, atlasRoot) {
@@ -36,26 +44,62 @@ function runCli(args, atlasRoot) {
   return result;
 }
 
-async function seedProofRoot(root, overrides = {}) {
+function assertFailureSurface(result, expected) {
+  assert.equal(
+    result.status,
+    1,
+    `expected ${expected.name} to fail with exit 1, got ${result.status}\n${result.stdout}\n${result.stderr}`,
+  );
+  assert.match(
+    result.stderr,
+    new RegExp(`Failure category: ${expected.category}`, "i"),
+    `${expected.name} should report ${expected.category}:\n${result.stderr}`,
+  );
+  assert.match(
+    result.stderr,
+    /First remediation step:/i,
+    `${expected.name} should include the first remediation step:\n${result.stderr}`,
+  );
+  assert(
+    result.stderr.includes(expected.remediationIncludes),
+    `${expected.name} should include remediation text ${expected.remediationIncludes}:\n${result.stderr}`,
+  );
+  if (expected.detailIncludes) {
+    assert(
+      result.stderr.includes(expected.detailIncludes),
+      `${expected.name} should include detail ${expected.detailIncludes}:\n${result.stderr}`,
+    );
+  }
+}
+
+async function seedProofRoot(root, options = {}) {
   await writeFile(path.join(root, "stack.yaml"), "name: ATLAS\n", "utf8");
 
-  const semanticRef = "runtime\\atlas\\ui-observe\\drift\\fitness\\latest.json";
-  const visualRef = "runtime\\atlas\\ui-visual-proof\\fitness\\latest.json";
-  const summaryRef = "runtime\\atlas\\ui-proof\\fitness\\latest.json";
+  const semanticRef =
+    options.semanticRef ?? "runtime\\atlas\\ui-observe\\drift\\fitness\\latest.json";
+  const visualRef =
+    options.visualRef ?? "runtime\\atlas\\ui-visual-proof\\fitness\\latest.json";
+  const summaryRef = options.summaryRef ?? "runtime\\atlas\\ui-proof\\fitness\\latest.json";
 
-  await writeJson(path.join(root, semanticRef), {
-    contract_version: "atlas.ui.drift-report.v1",
-    report_id: "sha256:semantic-proof-clean",
-    status: "clean",
-    finding_count: 0,
-  });
-  await writeJson(path.join(root, visualRef), {
-    contract_version: "atlas.ui.visual-proof.v1",
-    report_id: "sha256:visual-proof-clean",
-    status: "clean",
-    gated_capture_count: 2,
-    failed_capture_ids: [],
-  });
+  if (options.writeSemanticReport !== false) {
+    await writeJson(resolveFixturePath(root, semanticRef), {
+      contract_version: "atlas.ui.drift-report.v1",
+      report_id: "sha256:semantic-proof-clean",
+      status: "clean",
+      finding_count: 0,
+      ...(options.semanticReport ?? {}),
+    });
+  }
+  if (options.writeVisualReport !== false) {
+    await writeJson(resolveFixturePath(root, visualRef), {
+      contract_version: "atlas.ui.visual-proof.v1",
+      report_id: "sha256:visual-proof-clean",
+      status: "clean",
+      gated_capture_count: 2,
+      failed_capture_ids: [],
+      ...(options.visualReport ?? {}),
+    });
+  }
 
   const summary = {
     contract_version: "atlas.ui.proof-summary.v1",
@@ -92,14 +136,15 @@ async function seedProofRoot(root, overrides = {}) {
     operator_summary: [
       "Semantic drift clean and visual proof clean across 2 gated captures.",
     ],
-    ...overrides,
+    ...(options.overrides ?? {}),
   };
-  await writeJson(path.join(root, summaryRef), summary);
+  await writeJson(resolveFixturePath(root, summaryRef), summary);
 
   return {
     semanticRef,
     visualRef,
-    summaryPath: path.join(root, summaryRef),
+    summaryRef,
+    summaryPath: resolveFixturePath(root, summaryRef),
   };
 }
 
@@ -172,10 +217,100 @@ async function main() {
     const repeatReceipt = JSON.parse(await readFile(repeatReceiptPath, "utf8"));
     assert.equal(repeatReceipt.receipt_id, receipt.receipt_id);
 
+    const absoluteRefRoot = await mkdtemp(
+      path.join(os.tmpdir(), "lifeline-ui-proof-absolute-"),
+    );
+    try {
+      const absoluteSemanticRef = path.join(
+        absoluteRefRoot,
+        "runtime",
+        "atlas",
+        "ui-observe",
+        "drift",
+        "fitness",
+        "latest.json",
+      );
+      const absoluteVisualRef = path.join(
+        absoluteRefRoot,
+        "runtime",
+        "atlas",
+        "ui-visual-proof",
+        "fitness",
+        "latest.json",
+      );
+      const absoluteSeed = await seedProofRoot(absoluteRefRoot, {
+        semanticRef: absoluteSemanticRef,
+        visualRef: absoluteVisualRef,
+      });
+      const absoluteSuccess = runCli(
+        [
+          "proof-pass",
+          absoluteSeed.summaryPath,
+          "--source-repo",
+          "fitness",
+          "--tranche",
+          "F12",
+        ],
+        absoluteRefRoot,
+      );
+      assert.equal(
+        absoluteSuccess.status,
+        0,
+        `absolute ATLAS refs should still emit a receipt:\n${absoluteSuccess.stdout}\n${absoluteSuccess.stderr}`,
+      );
+      const absoluteReceiptPath = parseReceiptPath(absoluteSuccess.stdout);
+      assert(absoluteReceiptPath, "absolute ref success did not print a receipt path");
+      const absoluteReceipt = JSON.parse(
+        await readFile(absoluteReceiptPath, "utf8"),
+      );
+      assert.equal(
+        absoluteReceipt.proof_summary.summary_ref,
+        "runtime/atlas/ui-proof/fitness/latest.json",
+      );
+      assert.equal(
+        absoluteReceipt.proof_refs.semantic_report_ref,
+        "runtime/atlas/ui-observe/drift/fitness/latest.json",
+      );
+      assert.equal(
+        absoluteReceipt.proof_refs.visual_report_ref,
+        "runtime/atlas/ui-visual-proof/fitness/latest.json",
+      );
+      assert.deepEqual(absoluteReceipt.source_refs, [
+        "runtime/atlas/ui-proof/fitness/latest.json",
+        "runtime/atlas/ui-observe/drift/fitness/latest.json",
+        "runtime/atlas/ui-visual-proof/fitness/latest.json",
+      ]);
+      assert.equal(
+        absoluteReceipt.proof_refs.semantic_report_ref.includes(":"),
+        false,
+        "absolute ATLAS refs should be rewritten to stack-relative refs",
+      );
+      assert.equal(
+        absoluteReceipt.proof_refs.visual_report_ref.includes(":"),
+        false,
+        "absolute ATLAS refs should be rewritten to stack-relative refs",
+      );
+      assert.equal(
+        absoluteReceipt.source_refs.some((entry) => entry.includes("\\")),
+        false,
+        "emitted source refs should stay slash-normalized",
+      );
+    } finally {
+      await rm(absoluteRefRoot, { recursive: true, force: true });
+    }
+
+    const missingSummaryPath = path.join(
+      tempRoot,
+      "runtime",
+      "atlas",
+      "ui-proof",
+      "fitness",
+      "missing.json",
+    );
     const missingSummary = runCli(
       [
         "proof-pass",
-        path.join(tempRoot, "runtime", "atlas", "ui-proof", "fitness", "missing.json"),
+        missingSummaryPath,
         "--source-repo",
         "fitness",
         "--tranche",
@@ -183,34 +318,126 @@ async function main() {
       ],
       tempRoot,
     );
-    assert.equal(missingSummary.status, 1);
-    assert.match(
-      missingSummary.stderr,
-      /Failure category: environment_error[\s\S]*First remediation step:/i,
-      "missing summary should fail with a read error",
+    assertFailureSurface(missingSummary, {
+      name: "missing summary",
+      category: "environment_error",
+      remediationIncludes:
+        "Verify the proof summary path and the referenced proof reports are readable, then rerun.",
+      detailIncludes: normalizePath(missingSummaryPath),
+    });
+
+    const missingSemanticRoot = await mkdtemp(
+      path.join(os.tmpdir(), "lifeline-ui-proof-missing-semantic-"),
     );
+    try {
+      const missingSemanticSeed = await seedProofRoot(missingSemanticRoot, {
+        semanticRef: "runtime\\atlas\\ui-observe\\drift\\fitness\\missing.json",
+        writeSemanticReport: false,
+      });
+      const missingSemantic = runCli(
+        [
+          "proof-pass",
+          missingSemanticSeed.summaryPath,
+          "--source-repo",
+          "fitness",
+          "--tranche",
+          "F11",
+        ],
+        missingSemanticRoot,
+      );
+      assertFailureSurface(missingSemantic, {
+        name: "missing semantic proof report",
+        category: "environment_error",
+        remediationIncludes:
+          "Verify the proof summary path and the referenced proof reports are readable, then rerun.",
+        detailIncludes: "runtime/atlas/ui-observe/drift/fitness/missing.json",
+      });
+    } finally {
+      await rm(missingSemanticRoot, { recursive: true, force: true });
+    }
+
+    const malformedSummaryRoot = await mkdtemp(
+      path.join(os.tmpdir(), "lifeline-ui-proof-malformed-"),
+    );
+    try {
+      const malformedSeed = await seedProofRoot(malformedSummaryRoot);
+      await writeFile(
+        malformedSeed.summaryPath,
+        "{ not-valid-json }\n",
+        "utf8",
+      );
+      const malformedSummary = runCli(
+        [
+          "proof-pass",
+          malformedSeed.summaryPath,
+          "--source-repo",
+          "fitness",
+          "--tranche",
+          "F11",
+        ],
+        malformedSummaryRoot,
+      );
+      assertFailureSurface(malformedSummary, {
+        name: "malformed summary",
+        category: "config_error",
+        remediationIncludes:
+          "Fix the proof summary, source repo, or tranche arguments so they match the ATLAS proof contract, then rerun.",
+        detailIncludes: "Could not parse JSON",
+      });
+    } finally {
+      await rm(malformedSummaryRoot, { recursive: true, force: true });
+    }
+
+    const mismatchedOwnerRoot = await mkdtemp(
+      path.join(os.tmpdir(), "lifeline-ui-proof-owner-mismatch-"),
+    );
+    try {
+      const mismatchedOwnerSeed = await seedProofRoot(mismatchedOwnerRoot);
+      const mismatchedOwner = runCli(
+        [
+          "proof-pass",
+          mismatchedOwnerSeed.summaryPath,
+          "--source-repo",
+          "mazer",
+          "--tranche",
+          "F11",
+        ],
+        mismatchedOwnerRoot,
+      );
+      assertFailureSurface(mismatchedOwner, {
+        name: "owner mismatch",
+        category: "config_error",
+        remediationIncludes:
+          "Fix the proof summary, source repo, or tranche arguments so they match the ATLAS proof contract, then rerun.",
+        detailIncludes: "does not match proof summary owner_repo_id",
+      });
+    } finally {
+      await rm(mismatchedOwnerRoot, { recursive: true, force: true });
+    }
 
     const semanticBlockedRoot = await mkdtemp(
       path.join(os.tmpdir(), "lifeline-ui-proof-semantic-"),
     );
     try {
       const semanticSeed = await seedProofRoot(semanticBlockedRoot, {
-        completion_ready: false,
-        blocking_reasons: ["semantic drift detected"],
-        summary: {
-          status: "proof_blocked",
-          semantic_status: "drift_detected",
-          visual_status: "clean",
-          gated_capture_count: 2,
-          failed_capture_count: 1,
-        },
-        semantic_proof: {
-          status: "drift_detected",
-          report_ref: "runtime/atlas/ui-observe/drift/fitness/latest.json",
-          report_id: "sha256:semantic-proof-drift",
-          finding_count: 1,
-          failed_capture_ids: ["curated-onboarding-shell"],
-          errors: [],
+        overrides: {
+          completion_ready: true,
+          blocking_reasons: ["semantic drift detected"],
+          summary: {
+            status: "proof_blocked",
+            semantic_status: "drift_detected",
+            visual_status: "clean",
+            gated_capture_count: 2,
+            failed_capture_count: 1,
+          },
+          semantic_proof: {
+            status: "drift_detected",
+            report_ref: "runtime/atlas/ui-observe/drift/fitness/latest.json",
+            report_id: "sha256:semantic-proof-drift",
+            finding_count: 1,
+            failed_capture_ids: ["curated-onboarding-shell"],
+            errors: [],
+          },
         },
       });
       const semanticBlocked = runCli(
@@ -224,12 +451,13 @@ async function main() {
         ],
         semanticBlockedRoot,
       );
-      assert.equal(semanticBlocked.status, 1);
-      assert.match(
-        semanticBlocked.stderr,
-        /Failure category: config_error[\s\S]*First remediation step:/i,
-        "red semantic proof should block receipt emission",
-      );
+      assertFailureSurface(semanticBlocked, {
+        name: "semantic proof blocked",
+        category: "config_error",
+        remediationIncludes:
+          "Fix the proof summary, source repo, or tranche arguments so they match the ATLAS proof contract, then rerun.",
+        detailIncludes: "does not have clean semantic proof",
+      });
     } finally {
       await rm(semanticBlockedRoot, { recursive: true, force: true });
     }
@@ -239,22 +467,24 @@ async function main() {
     );
     try {
       const visualSeed = await seedProofRoot(visualBlockedRoot, {
-        completion_ready: false,
-        blocking_reasons: ["visual proof failed"],
-        summary: {
-          status: "proof_blocked",
-          semantic_status: "clean",
-          visual_status: "proof_failed",
-          gated_capture_count: 2,
-          failed_capture_count: 1,
-        },
-        visual_proof: {
-          status: "proof_failed",
-          report_ref: "runtime/atlas/ui-visual-proof/fitness/latest.json",
-          report_id: "sha256:visual-proof-failed",
-          gated_capture_count: 2,
-          failed_capture_ids: ["today-overview-default"],
-          errors: ["unexpected visual delta"],
+        overrides: {
+          completion_ready: true,
+          blocking_reasons: ["visual proof failed"],
+          summary: {
+            status: "proof_blocked",
+            semantic_status: "clean",
+            visual_status: "proof_failed",
+            gated_capture_count: 2,
+            failed_capture_count: 1,
+          },
+          visual_proof: {
+            status: "proof_failed",
+            report_ref: "runtime/atlas/ui-visual-proof/fitness/latest.json",
+            report_id: "sha256:visual-proof-failed",
+            gated_capture_count: 2,
+            failed_capture_ids: ["today-overview-default"],
+            errors: ["unexpected visual delta"],
+          },
         },
       });
       const visualBlocked = runCli(
@@ -268,12 +498,13 @@ async function main() {
         ],
         visualBlockedRoot,
       );
-      assert.equal(visualBlocked.status, 1);
-      assert.match(
-        visualBlocked.stderr,
-        /Failure category: config_error[\s\S]*First remediation step:/i,
-        "red visual proof should block receipt emission",
-      );
+      assertFailureSurface(visualBlocked, {
+        name: "visual proof blocked",
+        category: "config_error",
+        remediationIncludes:
+          "Fix the proof summary, source repo, or tranche arguments so they match the ATLAS proof contract, then rerun.",
+        detailIncludes: "does not have clean visual proof",
+      });
     } finally {
       await rm(visualBlockedRoot, { recursive: true, force: true });
     }

--- a/src/commands/proof-pass.ts
+++ b/src/commands/proof-pass.ts
@@ -75,7 +75,8 @@ function categorizeProofPassError(error: unknown): OperatorFailureSurface {
     if (
       message.includes("could not read json file") ||
       message.includes("could not resolve relative proof report ref") ||
-      message.includes("is not readable")
+      message.includes("is not readable") ||
+      message.includes("unreadable file")
     ) {
       return {
         category: "environment_error",

--- a/src/core/ui-proof-receipt.ts
+++ b/src/core/ui-proof-receipt.ts
@@ -214,6 +214,25 @@ function relativeAtlasRef(atlasRoot: string, targetPath: string): string {
   return normalizeReceiptPath(path.relative(atlasRoot, targetPath));
 }
 
+function canonicalizeAtlasRef(atlasRoot: string | null, ref: string): string {
+  const normalizedRef = normalizeReceiptPath(ref);
+  if (!atlasRoot) {
+    return normalizedRef;
+  }
+
+  const resolvedPath = resolveRefPath(atlasRoot, ref);
+  const relativeRef = path.relative(atlasRoot, resolvedPath);
+  if (
+    relativeRef.length > 0 &&
+    !relativeRef.startsWith("..") &&
+    !path.isAbsolute(relativeRef)
+  ) {
+    return normalizeReceiptPath(relativeRef);
+  }
+
+  return normalizedRef;
+}
+
 function resolveRefPath(atlasRoot: string | null, ref: string): string {
   if (path.isAbsolute(ref)) {
     return path.resolve(ref);
@@ -310,13 +329,21 @@ export async function emitUiProofPassedReceipt(options: {
   const proofSummaryRef = atlasRoot
     ? relativeAtlasRef(atlasRoot, proofSummaryPath)
     : normalizeReceiptPath(proofSummaryPath);
+  const semanticReportRef = canonicalizeAtlasRef(
+    atlasRoot,
+    proofSummary.semantic_proof.report_ref,
+  );
+  const visualReportRef = canonicalizeAtlasRef(
+    atlasRoot,
+    proofSummary.visual_proof.report_ref,
+  );
   const receiptIdentity = {
     sourceRepoId: options.sourceRepoId,
     trancheId: options.trancheId,
     proofSummaryRef,
     proofSummaryReportId: proofSummary.report_id,
-    semanticReportRef: proofSummary.semantic_proof.report_ref,
-    visualReportRef: proofSummary.visual_proof.report_ref,
+    semanticReportRef,
+    visualReportRef,
     ...(proofSummary.semantic_proof.report_id !== undefined
       ? { semanticReportId: proofSummary.semantic_proof.report_id }
       : {}),
@@ -340,24 +367,16 @@ export async function emitUiProofPassedReceipt(options: {
       report_id: proofSummary.report_id,
     },
     proof_refs: {
-      semantic_report_ref: normalizeReceiptPath(
-        proofSummary.semantic_proof.report_ref,
-      ),
+      semantic_report_ref: semanticReportRef,
       ...(proofSummary.semantic_proof.report_id !== undefined
         ? { semantic_report_id: proofSummary.semantic_proof.report_id }
         : {}),
-      visual_report_ref: normalizeReceiptPath(
-        proofSummary.visual_proof.report_ref,
-      ),
+      visual_report_ref: visualReportRef,
       ...(proofSummary.visual_proof.report_id !== undefined
         ? { visual_report_id: proofSummary.visual_proof.report_id }
         : {}),
     },
-    source_refs: [
-      proofSummaryRef,
-      normalizeReceiptPath(proofSummary.semantic_proof.report_ref),
-      normalizeReceiptPath(proofSummary.visual_proof.report_ref),
-    ],
+    source_refs: [proofSummaryRef, semanticReportRef, visualReportRef],
   };
 
   const receiptDir =


### PR DESCRIPTION
## Summary

- add explicit deterministic preflight rejection fixtures for:
  - node-version
  - package-manager
  - shell-runtime
  - repo-prerequisite
- assert remediation text for the CLI mismatch case
- expand proof-pass deterministic coverage for:
  - unreadable proof refs
  - malformed summaries
  - owner mismatches
  - semantic/visual blocked states
  - Windows-oriented ATLAS-internal absolute path normalization
- canonicalize ATLAS-internal proof refs to stack-relative forward-slash refs in emitted receipts
- classify unreadable proof-report failures as `environment_error`
- update the proof-pass receipt contract docs and PLAYBOOK_NOTES

## Verification

- `node scripts/test-preflight-deterministic.mjs`
- `node scripts/test-ui-proof-receipt-deterministic.mjs`
- `pnpm run verify`