### PR TITLE
Lifeline: align hosted CI with canonical verify contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,16 @@
 name: CI
 
 on:
-  push:
   pull_request:
+  push:
+    branches: [main]
 
 env:
   NPM_CONFIG_OPTIONAL: "true"
   PNPM_CONFIG_OPTIONAL: "true"
 
 jobs:
-  validate:
+  verify:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,126 +33,5 @@ jobs:
       - name: Verify esbuild optional package resolution
         run: pnpm ci:verify:esbuild
 
-      - name: Typecheck
-        run: pnpm typecheck
-
-      - name: Build
-        run: pnpm build
-
-      - name: Validate fitness manifest
-        run: pnpm lifeline validate examples/fitness-app.lifeline.yml
-
-      - name: Validate Playbook UI manifest
-        run: pnpm lifeline validate examples/playbook-ui.lifeline.yml
-
-      - name: Smoke preflight
-        run: node scripts/lib/ensure-built.mjs
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: lifeline-dist
-          path: dist
-          if-no-files-found: error
-
-  suite-matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      smoke_suites: ${{ steps.suites.outputs.smoke_suites }}
-      deterministic_suites: ${{ steps.suites.outputs.deterministic_suites }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Determine suite matrices
-        id: suites
-        run: |
-          smoke_suites=$(node -e "const suites=require('./scripts/smoke-suites.json'); process.stdout.write(JSON.stringify(Object.keys(suites)));")
-          deterministic_suites=$(node -e "const suites=require('./scripts/test-suites.json'); process.stdout.write(JSON.stringify(Object.keys(suites)));")
-          echo "smoke_suites=$smoke_suites" >> "$GITHUB_OUTPUT"
-          echo "deterministic_suites=$deterministic_suites" >> "$GITHUB_OUTPUT"
-
-  smoke-suites:
-    name: smoke-suite (${{ matrix.suite }})
-    runs-on: ubuntu-latest
-    needs:
-      - validate
-      - suite-matrix
-    strategy:
-      fail-fast: false
-      matrix:
-        suite: ${{ fromJson(needs.suite-matrix.outputs.smoke_suites) }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.6.5
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
-
-      - name: Verify esbuild optional package resolution
-        run: pnpm ci:verify:esbuild
-
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: lifeline-dist
-          path: dist
-
-      - name: Smoke preflight
-        run: node scripts/lib/ensure-built.mjs
-
-      - name: Run smoke suite
-        run: node scripts/smoke-suite-runner.mjs ${{ matrix.suite }}
-
-  deterministic-suites:
-    name: deterministic-suite (${{ matrix.suite }})
-    runs-on: ubuntu-latest
-    needs:
-      - validate
-      - suite-matrix
-    strategy:
-      fail-fast: false
-      matrix:
-        suite: ${{ fromJson(needs.suite-matrix.outputs.deterministic_suites) }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.6.5
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
-
-      - name: Verify esbuild optional package resolution
-        run: pnpm ci:verify:esbuild
-
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: lifeline-dist
-          path: dist
-
-      - name: Run deterministic suite
-        run: node scripts/test-runner.mjs ${{ matrix.suite }}
+      - name: Run canonical repo verify contract
+        run: pnpm run verify

--- a/.github/workflows/playbook-verify.yml
+++ b/.github/workflows/playbook-verify.yml
@@ -1,16 +1,14 @@
-name: playbook-verify
+name: Playbook Smoke
 
 on:
-  pull_request:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 env:
   NPM_CONFIG_OPTIONAL: "true"
   PNPM_CONFIG_OPTIONAL: "true"
 
 jobs:
-  verify:
+  playbook-smoke:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,4 @@ Verification
   - `pnpm run build`
   - `pnpm run test:privileged-execution-bridge`
   - `pnpm run test:privileged-execution-repair`
+  - `pnpm run test:ui-proof-receipt`

--- a/docs/PLAYBOOK_NOTES.md
+++ b/docs/PLAYBOOK_NOTES.md
@@ -3,6 +3,22 @@
 Use this file to record meaningful code changes in a concise, reviewable format.
 Link related pull requests whenever possible.
 
+## 2026-04-22
+
+- WHAT changed:
+  - Replaced the PR and `main` hosted gate with one canonical GitHub Actions `verify` job that runs `pnpm run verify`.
+  - Removed workflow-side reconstruction of test lists so the hosted gate now covers the repair-receipt path through the same repo contract used locally.
+  - Demoted the Playbook smoke workflow to a manual supplemental lane so it no longer drifts into the authoritative PR or `main` gate.
+- WHY it changed:
+  - Hosted CI had broad coverage, but it still missed part of the declared `verify` contract and could drift as local verification changed.
+  - Branch protection should reflect the same narrow contract operators run before claiming repo-local completion.
+- Rule:
+  - Hosted CI must execute the same canonical verification contract as local repo verification.
+- Pattern:
+  - Prefer one authoritative `verify` entrypoint over duplicated workflow-specific test lists.
+- Failure mode addressed:
+  - Manually reconstructed workflow gates can miss verify-only coverage such as privileged execution receipt repair.
+
 ## 2026-04-21
 
 - WHAT changed:

--- a/scripts/test-privileged-execution-worker-bridge-deterministic.mjs
+++ b/scripts/test-privileged-execution-worker-bridge-deterministic.mjs
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
-import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -47,8 +47,161 @@ async function writeJson(filePath, payload) {
   await writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
 }
 
-async function currentRegistryDigest() {
-  const atlasRoot = path.resolve(repoRoot, "..", "..");
+async function createFixtureTempDir(atlasRoot, prefix) {
+  const tempRoot = path.join(atlasRoot, "tmp");
+  await mkdir(tempRoot, { recursive: true });
+  return mkdtemp(path.join(tempRoot, `${prefix}-`));
+}
+
+async function createAtlasFixtureRoot() {
+  const atlasRoot = await mkdtemp(
+    path.join(os.tmpdir(), "lifeline-atlas-fixture-"),
+  );
+  const readOnlyCapability = JSON.parse(
+    await readFile(path.join(examplesRoot, "capability-profile.json"), "utf8"),
+  );
+  const dryRunCapability = JSON.parse(
+    await readFile(
+      path.join(examplesRoot, "capability-profile.scoped-write-dry-run.json"),
+      "utf8",
+    ),
+  );
+  const workspaceCapability = {
+    contract_version: "atlas.capability.profile.v1",
+    capability_profile_id: "cap-atlas-workspace-file-apply-v1",
+    description: "ATLAS bounded workspace file apply capability profile.",
+    filesystem_scopes: {
+      read: ["runtime/atlas/session-workspaces/**"],
+      write: ["runtime/atlas/session-workspaces/**"],
+      create: ["runtime/atlas/session-workspaces/**"],
+      deny: ["secrets/**", "repos/Verta-Core/**"],
+    },
+    network_scopes: {
+      mode: "none",
+      allowed_domains: [],
+      blocked_domains: [],
+    },
+    process_execution_permissions: {
+      allow_spawn: false,
+      allow_shell: false,
+      allow_python: false,
+      allowed_commands: [],
+      denied_commands: ["powershell", "cmd", "git", "node", "python"],
+    },
+    package_manager_permissions: {
+      allow_install: false,
+      allow_update: false,
+      allowed_managers: [],
+      blocked_managers: ["npm", "pnpm", "yarn"],
+    },
+    elevation_requirement: "per_action_approval",
+    resource_budgets: {
+      wall_clock_seconds: 120,
+      cpu_seconds: 30,
+      memory_mb: 256,
+      disk_mb: 50,
+    },
+    allowed_data_classes: ["public", "internal", "machine_state"],
+    audit_class: "standard",
+  };
+
+  const toolRegistry = {
+    schema_version: "atlas.tool.registry.v1",
+    kind: "atlas-tool-registry",
+    entries: [
+      {
+        contract_version: "atlas.tool.catalog.entry.v1",
+        tool_id: "read_only_scan",
+        extension_id: null,
+        trust_class: "trusted",
+        release_eligible: true,
+        max_automation_level: "approved_action",
+        capability_profile: readOnlyCapability,
+        approval: {
+          required: true,
+          approver_kind: "system",
+          required_status: "approved",
+          granted_scope_required: true,
+        },
+        invocation: {
+          action_operation: "read_only_scan",
+          execution_mode: "read_only_scan",
+        },
+      },
+      {
+        contract_version: "atlas.tool.catalog.entry.v1",
+        tool_id: "scoped_write.dry_run",
+        extension_id: null,
+        trust_class: "trusted",
+        release_eligible: true,
+        max_automation_level: "approved_action",
+        capability_profile: dryRunCapability,
+        approval: {
+          required: true,
+          approver_kind: "system",
+          required_status: "approved",
+          granted_scope_required: true,
+        },
+        invocation: {
+          action_operation: "scoped_write",
+          execution_mode: "dry_run_command",
+        },
+      },
+      {
+        contract_version: "atlas.tool.catalog.entry.v1",
+        tool_id: "workspace_file_apply",
+        extension_id: null,
+        trust_class: "trusted",
+        release_eligible: true,
+        max_automation_level: "approved_action",
+        capability_profile: workspaceCapability,
+        approval: {
+          required: true,
+          approver_kind: "system",
+          required_status: "approved",
+          granted_scope_required: true,
+        },
+        invocation: {
+          action_operation: "scoped_write",
+          execution_mode: "workspace_file_apply",
+        },
+      },
+    ],
+  };
+
+  await writeFile(path.join(atlasRoot, "stack.yaml"), "stack_id: atlas-test\n", "utf8");
+  await writeFile(path.join(atlasRoot, "README.md"), "# Fixture root\n", "utf8");
+  await mkdir(path.join(atlasRoot, "docs"), { recursive: true });
+  await mkdir(path.join(atlasRoot, "ops", "atlas"), { recursive: true });
+  await writeFile(
+    path.join(atlasRoot, "docs", "privileged-execution.md"),
+    "# Privileged execution fixture\n",
+    "utf8",
+  );
+  await writeFile(
+    path.join(atlasRoot, "ops", "atlas", "observations.py"),
+    "if __name__ == '__main__':\n    raise SystemExit(0)\n",
+    "utf8",
+  );
+  await writeJson(
+    path.join(atlasRoot, "docs", "registry", "ATLAS-TOOL-REGISTRY.json"),
+    toolRegistry,
+  );
+  await writeJson(
+    path.join(atlasRoot, "docs", "registry", "ATLAS-EXTENSION-REGISTRY.json"),
+    {
+      schema_version: "atlas.extension.registry.v1",
+      kind: "atlas-extension-registry",
+      entries: [],
+    },
+  );
+  await mkdir(path.join(atlasRoot, "runtime", "atlas", "session-workspaces"), {
+    recursive: true,
+  });
+  return atlasRoot;
+}
+
+async function currentRegistryDigest(atlasRoot) {
   const registry = await loadGovernedRegistry(atlasRoot);
   return registry.registryDigest;
 }
@@ -80,6 +233,7 @@ function parseReceiptPath(stdout) {
 }
 
 async function runScenario({
+  atlasRoot,
   name,
   requestPath,
   approvalPath,
@@ -93,13 +247,13 @@ async function runScenario({
   let preparedCapabilityPath = capabilityProfilePath;
   let cleanupDir = null;
   if (!skipNormalize) {
-    const registryDigest = await currentRegistryDigest();
+    const registryDigest = await currentRegistryDigest(atlasRoot);
     const approval = JSON.parse(await readFile(approvalPath, "utf8"));
     const capability = JSON.parse(await readFile(capabilityProfilePath, "utf8"));
     normalizeScenarioPayloads({ request, approval, capability, registryDigest });
-    cleanupDir = path.join(
-      os.tmpdir(),
-      `lifeline-worker-bridge-inputs-${name}-${Date.now()}`,
+    cleanupDir = await createFixtureTempDir(
+      atlasRoot,
+      `lifeline-worker-bridge-inputs-${name}`,
     );
     preparedRequestPath = path.join(cleanupDir, "request.json");
     preparedApprovalPath = path.join(cleanupDir, "approval.json");
@@ -108,9 +262,9 @@ async function runScenario({
     await writeJson(preparedApprovalPath, approval);
     await writeJson(preparedCapabilityPath, capability);
   }
-  const receiptDir = path.join(
-    os.tmpdir(),
-    `lifeline-worker-bridge-receipts-${name}-${Date.now()}`,
+  const receiptDir = await createFixtureTempDir(
+    atlasRoot,
+    `lifeline-worker-bridge-receipts-${name}`,
   );
   const result = spawnSync(
     "node",
@@ -126,11 +280,11 @@ async function runScenario({
       receiptDir,
     ],
     {
-      cwd: repoRoot,
+      cwd: atlasRoot,
       encoding: "utf8",
       env: {
         ...process.env,
-        ATLAS_ROOT: path.resolve(repoRoot, "..", ".."),
+        ATLAS_ROOT: atlasRoot,
       },
     },
   );
@@ -153,6 +307,7 @@ async function runScenario({
 }
 
 async function createMutatedScenario({
+  atlasRoot,
   name,
   baseRequestName,
   baseApprovalName,
@@ -177,16 +332,16 @@ async function createMutatedScenario({
     request,
     approval,
     capability,
-    registryDigest: await currentRegistryDigest(),
+    registryDigest: await currentRegistryDigest(atlasRoot),
   });
   if (typeof afterNormalize === "function") {
     afterNormalize({ request, approval, capability });
     approval.request_digest = digestValue(request);
   }
 
-  const tempDir = path.join(
-    os.tmpdir(),
-    `lifeline-governed-surface-${name}-${Date.now()}`,
+  const tempDir = await createFixtureTempDir(
+    atlasRoot,
+    `lifeline-governed-surface-${name}`,
   );
   const requestPath = path.join(tempDir, "request.json");
   const approvalPath = path.join(tempDir, "approval.json");
@@ -196,6 +351,7 @@ async function createMutatedScenario({
   await writeJson(capabilityProfilePath, capability);
 
   return {
+    atlasRoot,
     name,
     requestPath,
     approvalPath,
@@ -208,13 +364,13 @@ async function createMutatedScenario({
 }
 
 async function createWorkspaceWriteScenario({
+  atlasRoot,
   name,
   mutate,
   afterNormalize,
   expectedExitCode,
   expectedBlockedReasonContains,
 }) {
-  const atlasRoot = path.resolve(repoRoot, "..", "..");
   const registry = await loadGovernedRegistry(atlasRoot);
   const tool = registry.tools.get("workspace_file_apply");
   if (!tool) {
@@ -289,15 +445,16 @@ async function createWorkspaceWriteScenario({
     approval.request_digest = digestValue(request);
   }
 
-  const tempDir = path.join(
-    os.tmpdir(),
-    `lifeline-workspace-write-${name}-${Date.now()}`,
+  const tempDir = await createFixtureTempDir(
+    atlasRoot,
+    `lifeline-workspace-write-${name}`,
   );
   await writeJson(path.join(tempDir, "request.json"), request);
   await writeJson(path.join(tempDir, "approval.json"), approval);
   await writeJson(path.join(tempDir, "capability.json"), capability);
 
   return {
+    atlasRoot,
     name,
     requestPath: path.join(tempDir, "request.json"),
     approvalPath: path.join(tempDir, "approval.json"),
@@ -315,260 +472,283 @@ async function main() {
     throw new Error("dist/cli.js is missing. Run `pnpm build` first.");
   });
 
-  const scenarios = [
-    {
-      name: "read-only",
-      requestPath: path.join(examplesRoot, "read-only-scan.request.json"),
-      approvalPath: path.join(examplesRoot, "read-only-scan.approval.json"),
-      capabilityProfilePath: path.join(examplesRoot, "capability-profile.json"),
-      expectedExitCode: 0,
-    },
-    {
-      name: "dry-run-approved",
-      requestPath: path.join(examplesRoot, "dry-run-command.request.json"),
-      approvalPath: path.join(examplesRoot, "dry-run-command.approval.json"),
-      capabilityProfilePath: path.join(
-        examplesRoot,
-        "capability-profile.scoped-write-dry-run.json",
-      ),
-      expectedExitCode: 0,
-    },
-    await createMutatedScenario({
-      name: "dry-run-crlf-output",
-      baseRequestName: "dry-run-command.request.json",
-      baseApprovalName: "dry-run-command.approval.json",
-      baseCapabilityName: "capability-profile.scoped-write-dry-run.json",
-      mutate: ({ request }) => {
-        request.action.command = [
-          "node",
-          "-e",
-          "process.stdout.write('line1\\r\\nline2\\r\\n')",
-        ];
-      },
-      expectedExitCode: 0,
-    }),
-    {
-      name: "dry-run-rejected",
-      requestPath: path.join(examplesRoot, "dry-run-command.request.json"),
-      approvalPath: path.join(
-        examplesRoot,
-        "dry-run-command.rejected.approval.json",
-      ),
-      capabilityProfilePath: path.join(
-        examplesRoot,
-        "capability-profile.scoped-write-dry-run.json",
-      ),
-      expectedExitCode: 1,
-      expectedBlockedReasonContains: "approval_status",
-    },
-    {
-      name: "dry-run-expired",
-      requestPath: path.join(examplesRoot, "dry-run-command.request.json"),
-      approvalPath: path.join(
-        examplesRoot,
-        "dry-run-command.expired.approval.json",
-      ),
-      capabilityProfilePath: path.join(
-        examplesRoot,
-        "capability-profile.scoped-write-dry-run.json",
-      ),
-      expectedExitCode: 1,
-      expectedBlockedReasonContains: "approval_status",
-    },
-    await createMutatedScenario({
-      name: "unknown-tool",
-      baseRequestName: "read-only-scan.request.json",
-      baseApprovalName: "read-only-scan.approval.json",
-      baseCapabilityName: "capability-profile.json",
-      mutate: ({ request, approval }) => {
-        request.tool_id = "unknown.tool";
-        approval.approval_status = "approved";
-      },
-      expectedExitCode: 1,
-      expectedBlockedReasonContains: "unknown tool_id",
-    }),
-    await createMutatedScenario({
-      name: "capability-mismatch",
-      baseRequestName: "read-only-scan.request.json",
-      baseApprovalName: "read-only-scan.approval.json",
-      baseCapabilityName: "capability-profile.json",
-      mutate: ({ request, approval, capability }) => {
-        request.requested_capability.allowed_data_classes = ["public"];
-        approval.granted_scope = request.requested_capability;
-        capability.allowed_data_classes = ["public"];
-      },
-      expectedExitCode: 1,
-      expectedBlockedReasonContains: "registered tool capability",
-    }),
-    await createWorkspaceWriteScenario({
-      name: "workspace-write-approved",
-      expectedExitCode: 0,
-    }),
-    await createWorkspaceWriteScenario({
-      name: "workspace-write-out-of-scope",
-      mutate: ({ request }) => {
-        request.action.write_target = "../outside.txt";
-        request.target_paths = [
-          request.action.workspace_root,
-          `${request.action.workspace_root}/../outside.txt`,
-        ];
-      },
-      expectedExitCode: 1,
-      expectedBlockedReasonContains: "escapes the declared workspace root",
-    }),
-    await createWorkspaceWriteScenario({
-      name: "workspace-write-automation-mismatch",
-      afterNormalize: ({ request }) => {
-        request.automation_level = "approved_action";
-      },
-      expectedExitCode: 1,
-      expectedBlockedReasonContains: "request.automation_level",
-    }),
-  ];
+  const atlasRoot = await createAtlasFixtureRoot();
 
-  for (const scenario of scenarios) {
-    const { receipt, receiptPath, receiptDir, request, cleanupDir, output } =
-      await runScenario(scenario);
-    assert(
-      Array.isArray(request.source_refs),
-      `${scenario.name}: request.source_refs missing`,
-    );
-    if (receipt) {
-      assert(
-        Array.isArray(receipt.source_refs),
-        `${scenario.name}: receipt.source_refs missing`,
-      );
-      assert(
-        JSON.stringify(receipt.source_refs) ===
-          JSON.stringify(request.source_refs),
-        `${scenario.name}: receipt.source_refs did not preserve the request source_refs`,
-      );
-      assert(
-        receipt.receipt_id.startsWith("sha256:"),
-        `${scenario.name}: receipt_id should be deterministic`,
-      );
-      assert(
-        receipt.worker_id === "worker-lifeline-01",
-        `${scenario.name}: worker_id mismatch`,
-      );
-      assert(
-        receipt.assignment_id.startsWith("assignment-lifeline-"),
-        `${scenario.name}: assignment_id mismatch`,
-      );
-      assert(
-        receipt.stack_lock_digest === "sha256:lifeline-stack-lock-001",
-        `${scenario.name}: stack_lock_digest mismatch`,
-      );
-      assert(
-        receipt.tool_id === request.tool_id,
-        `${scenario.name}: tool_id mismatch`,
-      );
-      assert(
-        receipt.extension_id === (request.extension_id ?? null),
-        `${scenario.name}: extension_id mismatch`,
-      );
-      assert(
-        receipt.registry_digest === request.registry_digest,
-        `${scenario.name}: registry_digest mismatch`,
-      );
-    }
+  try {
+    const scenarios = [
+      {
+        atlasRoot,
+        name: "read-only",
+        requestPath: path.join(examplesRoot, "read-only-scan.request.json"),
+        approvalPath: path.join(examplesRoot, "read-only-scan.approval.json"),
+        capabilityProfilePath: path.join(examplesRoot, "capability-profile.json"),
+        expectedExitCode: 0,
+      },
+      {
+        atlasRoot,
+        name: "dry-run-approved",
+        requestPath: path.join(examplesRoot, "dry-run-command.request.json"),
+        approvalPath: path.join(examplesRoot, "dry-run-command.approval.json"),
+        capabilityProfilePath: path.join(
+          examplesRoot,
+          "capability-profile.scoped-write-dry-run.json",
+        ),
+        expectedExitCode: 0,
+      },
+      await createMutatedScenario({
+        atlasRoot,
+        name: "dry-run-crlf-output",
+        baseRequestName: "dry-run-command.request.json",
+        baseApprovalName: "dry-run-command.approval.json",
+        baseCapabilityName: "capability-profile.scoped-write-dry-run.json",
+        mutate: ({ request }) => {
+          request.action.command = [
+            "node",
+            "-e",
+            "process.stdout.write('line1\\r\\nline2\\r\\n')",
+          ];
+        },
+        expectedExitCode: 0,
+      }),
+      {
+        atlasRoot,
+        name: "dry-run-rejected",
+        requestPath: path.join(examplesRoot, "dry-run-command.request.json"),
+        approvalPath: path.join(
+          examplesRoot,
+          "dry-run-command.rejected.approval.json",
+        ),
+        capabilityProfilePath: path.join(
+          examplesRoot,
+          "capability-profile.scoped-write-dry-run.json",
+        ),
+        expectedExitCode: 1,
+        expectedBlockedReasonContains: "approval_status",
+      },
+      {
+        atlasRoot,
+        name: "dry-run-expired",
+        requestPath: path.join(examplesRoot, "dry-run-command.request.json"),
+        approvalPath: path.join(
+          examplesRoot,
+          "dry-run-command.expired.approval.json",
+        ),
+        capabilityProfilePath: path.join(
+          examplesRoot,
+          "capability-profile.scoped-write-dry-run.json",
+        ),
+        expectedExitCode: 1,
+        expectedBlockedReasonContains: "approval_status",
+      },
+      await createMutatedScenario({
+        atlasRoot,
+        name: "unknown-tool",
+        baseRequestName: "read-only-scan.request.json",
+        baseApprovalName: "read-only-scan.approval.json",
+        baseCapabilityName: "capability-profile.json",
+        mutate: ({ request, approval }) => {
+          request.tool_id = "unknown.tool";
+          approval.approval_status = "approved";
+        },
+        expectedExitCode: 1,
+        expectedBlockedReasonContains: "unknown tool_id",
+      }),
+      await createMutatedScenario({
+        atlasRoot,
+        name: "capability-mismatch",
+        baseRequestName: "read-only-scan.request.json",
+        baseApprovalName: "read-only-scan.approval.json",
+        baseCapabilityName: "capability-profile.json",
+        mutate: ({ request, approval, capability }) => {
+          request.requested_capability.allowed_data_classes = ["public"];
+          approval.granted_scope = request.requested_capability;
+          capability.allowed_data_classes = ["public"];
+        },
+        expectedExitCode: 1,
+        expectedBlockedReasonContains: "registered tool capability",
+      }),
+      await createWorkspaceWriteScenario({
+        atlasRoot,
+        name: "workspace-write-approved",
+        expectedExitCode: 0,
+      }),
+      await createWorkspaceWriteScenario({
+        atlasRoot,
+        name: "workspace-write-out-of-scope",
+        mutate: ({ request }) => {
+          request.action.write_target = "../outside.txt";
+          request.target_paths = [
+            request.action.workspace_root,
+            `${request.action.workspace_root}/../outside.txt`,
+          ];
+        },
+        expectedExitCode: 1,
+        expectedBlockedReasonContains: "escapes the declared workspace root",
+      }),
+      await createWorkspaceWriteScenario({
+        atlasRoot,
+        name: "workspace-write-automation-mismatch",
+        afterNormalize: ({ request }) => {
+          request.automation_level = "approved_action";
+        },
+        expectedExitCode: 1,
+        expectedBlockedReasonContains: "request.automation_level",
+      }),
+    ];
 
-    if (scenario.expectedExitCode === 0) {
-      assert(receipt, `${scenario.name}: expected a receipt`);
+    for (const scenario of scenarios) {
+      const { receipt, receiptPath, receiptDir, request, cleanupDir, output } =
+        await runScenario(scenario);
       assert(
-        receipt.result === "succeeded",
-        `${scenario.name}: expected succeeded receipt`,
+        Array.isArray(request.source_refs),
+        `${scenario.name}: request.source_refs missing`,
       );
-      assert(
-        !receipt.failure,
-        `${scenario.name}: successful receipts should not carry failure metadata`,
-      );
-      if (scenario.name === "read-only") {
-        assert(
-          receipt.execution_mode === "read_only_scan",
-          `${scenario.name}: execution_mode mismatch`,
-        );
-        assert(
-          receipt.inspection && receipt.inspection.records.length === 2,
-          `${scenario.name}: expected two inspection records`,
-        );
-      } else {
-        if (scenario.name.startsWith("workspace-write")) {
-          assert(
-            receipt.execution_mode === "workspace_file_apply",
-            `${scenario.name}: execution_mode mismatch`,
-          );
-          assert(
-            Array.isArray(receipt.write_results) &&
-              receipt.write_results.length === 1,
-            `${scenario.name}: expected one write result`,
-          );
-        } else {
-          assert(
-          receipt.execution_mode === "dry_run_command",
-          `${scenario.name}: execution_mode mismatch`,
-        );
-          assert(
-          receipt.command_result && receipt.command_result.exit_code === 0,
-          `${scenario.name}: expected successful dry-run command`,
-        );
-          if (scenario.name === "dry-run-crlf-output") {
-            assert(
-              receipt.command_result.stdout === "line1\nline2\n",
-              `${scenario.name}: expected normalized stdout`,
-            );
-            assert(!receipt.command_result.stdout.includes("\r"));
-          }
-        }
-      }
-    } else {
       if (receipt) {
         assert(
-          receipt.result === "blocked",
-          `${scenario.name}: expected blocked receipt`,
+          Array.isArray(receipt.source_refs),
+          `${scenario.name}: receipt.source_refs missing`,
+        );
+        assert(
+          JSON.stringify(receipt.source_refs) ===
+            JSON.stringify(request.source_refs),
+          `${scenario.name}: receipt.source_refs did not preserve the request source_refs`,
         );
         assert(
           receipt.receipt_id.startsWith("sha256:"),
-          `${scenario.name}: blocked receipt_id should be deterministic`,
+          `${scenario.name}: receipt_id should be deterministic`,
         );
         assert(
-          receipt.failure &&
-            receipt.failure.category === "config_error" &&
-            receipt.failure.first_remediation_step.length > 0,
-          `${scenario.name}: blocked receipt missing failure surface`,
+          receipt.worker_id === "worker-lifeline-01",
+          `${scenario.name}: worker_id mismatch`,
         );
         assert(
-          typeof receipt.blocked_reason === "string" &&
-            receipt.blocked_reason.length > 0,
-          `${scenario.name}: blocked receipt missing reason`,
+          receipt.assignment_id.startsWith("assignment-lifeline-"),
+          `${scenario.name}: assignment_id mismatch`,
         );
-        if (scenario.expectedBlockedReasonContains) {
+        assert(
+          receipt.stack_lock_digest === "sha256:lifeline-stack-lock-001",
+          `${scenario.name}: stack_lock_digest mismatch`,
+        );
+        assert(
+          receipt.tool_id === request.tool_id,
+          `${scenario.name}: tool_id mismatch`,
+        );
+        assert(
+          receipt.extension_id === (request.extension_id ?? null),
+          `${scenario.name}: extension_id mismatch`,
+        );
+        assert(
+          receipt.registry_digest === request.registry_digest,
+          `${scenario.name}: registry_digest mismatch`,
+        );
+      }
+
+      if (scenario.expectedExitCode === 0) {
+        assert(receipt, `${scenario.name}: expected a receipt`);
+        assert(
+          receipt.result === "succeeded",
+          `${scenario.name}: expected succeeded receipt`,
+        );
+        assert(
+          !receipt.failure,
+          `${scenario.name}: successful receipts should not carry failure metadata`,
+        );
+        if (scenario.name === "read-only") {
           assert(
-            receipt.blocked_reason.includes(scenario.expectedBlockedReasonContains),
-            `${scenario.name}: blocked reason did not mention ${scenario.expectedBlockedReasonContains}`,
+            receipt.execution_mode === "read_only_scan",
+            `${scenario.name}: execution_mode mismatch`,
+          );
+          assert(
+            receipt.inspection && receipt.inspection.records.length === 2,
+            `${scenario.name}: expected two inspection records`,
+          );
+        } else {
+          if (scenario.name.startsWith("workspace-write")) {
+            assert(
+              receipt.execution_mode === "workspace_file_apply",
+              `${scenario.name}: execution_mode mismatch`,
+            );
+            assert(
+              Array.isArray(receipt.write_results) &&
+                receipt.write_results.length === 1,
+              `${scenario.name}: expected one write result`,
+            );
+          } else {
+            assert(
+              receipt.execution_mode === "dry_run_command",
+              `${scenario.name}: execution_mode mismatch`,
+            );
+            assert(
+              receipt.command_result && receipt.command_result.exit_code === 0,
+              `${scenario.name}: expected successful dry-run command`,
+            );
+            if (scenario.name === "dry-run-crlf-output") {
+              assert(
+                receipt.command_result.stdout === "line1\nline2\n",
+                `${scenario.name}: expected normalized stdout`,
+              );
+              assert(!receipt.command_result.stdout.includes("\r"));
+            }
+          }
+        }
+      } else {
+        if (receipt) {
+          assert(
+            receipt.result === "blocked",
+            `${scenario.name}: expected blocked receipt`,
+          );
+          assert(
+            receipt.receipt_id.startsWith("sha256:"),
+            `${scenario.name}: blocked receipt_id should be deterministic`,
+          );
+          assert(
+            receipt.failure &&
+              receipt.failure.category === "config_error" &&
+              receipt.failure.first_remediation_step.length > 0,
+            `${scenario.name}: blocked receipt missing failure surface`,
+          );
+          assert(
+            typeof receipt.blocked_reason === "string" &&
+              receipt.blocked_reason.length > 0,
+            `${scenario.name}: blocked receipt missing reason`,
+          );
+          if (scenario.expectedBlockedReasonContains) {
+            assert(
+              receipt.blocked_reason.includes(
+                scenario.expectedBlockedReasonContains,
+              ),
+              `${scenario.name}: blocked reason did not mention ${scenario.expectedBlockedReasonContains}`,
+            );
+          }
+        } else if (scenario.expectedBlockedReasonContains) {
+          assert(
+            output.includes(scenario.expectedBlockedReasonContains),
+            `${scenario.name}: expected failure output to mention ${scenario.expectedBlockedReasonContains}`,
+          );
+        } else {
+          throw new Error(
+            `${scenario.name}: expected a receipt or explicit failure output.`,
           );
         }
-      } else if (scenario.expectedBlockedReasonContains) {
-        assert(
-          output.includes(scenario.expectedBlockedReasonContains),
-          `${scenario.name}: expected failure output to mention ${scenario.expectedBlockedReasonContains}`,
-        );
-      } else {
-        throw new Error(`${scenario.name}: expected a receipt or explicit failure output.`);
       }
-    }
 
-    await rm(receiptDir, { recursive: true, force: true });
-    if (cleanupDir) {
-      await rm(cleanupDir, { recursive: true, force: true });
+      await rm(receiptDir, { recursive: true, force: true });
+      if (cleanupDir) {
+        await rm(cleanupDir, { recursive: true, force: true });
+      }
+      if (scenario.cleanupDir) {
+        await rm(scenario.cleanupDir, { recursive: true, force: true });
+      }
+      if (scenario.workspaceRootAbsolute) {
+        await rm(scenario.workspaceRootAbsolute, {
+          recursive: true,
+          force: true,
+        });
+      }
+      console.log(`${scenario.name}: ${receiptPath ?? "no-receipt"}`);
     }
-    if (scenario.cleanupDir) {
-      await rm(scenario.cleanupDir, { recursive: true, force: true });
-    }
-    if (scenario.workspaceRootAbsolute) {
-      await rm(scenario.workspaceRootAbsolute, { recursive: true, force: true });
-    }
-    console.log(`${scenario.name}: ${receiptPath ?? "no-receipt"}`);
+  } finally {
+    await rm(atlasRoot, { recursive: true, force: true });
   }
 }
 


### PR DESCRIPTION
## Summary

- make GitHub Actions run the canonical repo-local gate via `pnpm run verify`
- ensure hosted CI covers `test:privileged-execution-repair` through the same path declared in `package.json`
- demote the playbook smoke workflow to manual `workflow_dispatch` so it no longer competes as a merge gate
- update repo notes and AGENTS guidance so local/operator instructions match the hosted verification contract

## Verification

- `pnpm run verify`
- validated workflow YAML with `pnpm dlx js-yaml`