### PR TITLE
Lifeline: document required verify merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   verify:
+    name: verify
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ pnpm test:startup-roundtrip
 
 `node scripts/lib/ensure-built.mjs` is the canonical smoke preflight. It fails early with explicit setup errors (missing/stale `dist/cli.js`) so smoke failures that follow are runtime/regression signals.
 
-CI uses the same canonical Playbook verification path: `pnpm smoke:playbook`.
+The canonical repo verification contract is `pnpm run verify`. GitHub Actions enforces that same contract through the required `verify` check on pull requests, while `Playbook Smoke` remains a manual supplemental lane.
 
 ### Smoke execution modes
 

--- a/docs/PLAYBOOK_CHECKLIST.md
+++ b/docs/PLAYBOOK_CHECKLIST.md
@@ -2,4 +2,5 @@
 
 - [ ] Updated architecture docs if behavior changed
 - [ ] Added note entry with WHAT/WHY
-- [ ] Verified `pnpm smoke:playbook` passes
+- [ ] Verified `pnpm run verify` passes
+- [ ] Confirmed GitHub merge policy points at the required `verify` check, not `Playbook Smoke`

--- a/docs/PLAYBOOK_NOTES.md
+++ b/docs/PLAYBOOK_NOTES.md
@@ -9,15 +9,16 @@ Link related pull requests whenever possible.
   - Replaced the PR and `main` hosted gate with one canonical GitHub Actions `verify` job that runs `pnpm run verify`.
   - Removed workflow-side reconstruction of test lists so the hosted gate now covers the repair-receipt path through the same repo contract used locally.
   - Demoted the Playbook smoke workflow to a manual supplemental lane so it no longer drifts into the authoritative PR or `main` gate.
+  - Documented the exact required merge check as `verify` and pinned the hosted job name explicitly so branch protection can target a stable check run.
 - WHY it changed:
   - Hosted CI had broad coverage, but it still missed part of the declared `verify` contract and could drift as local verification changed.
   - Branch protection should reflect the same narrow contract operators run before claiming repo-local completion.
 - Rule:
-  - Hosted CI must execute the same canonical verification contract as local repo verification.
+  - Hosted CI must execute the same canonical verification contract as local repo verification, and merge policy must require that exact hosted `verify` check.
 - Pattern:
-  - Prefer one authoritative `verify` entrypoint over duplicated workflow-specific test lists.
+  - Prefer one authoritative `verify` entrypoint and one explicit hosted `verify` check over duplicated workflow-specific test lists or ambiguous required-check names.
 - Failure mode addressed:
-  - Manually reconstructed workflow gates can miss verify-only coverage such as privileged execution receipt repair.
+  - Manually reconstructed workflow gates or mismatched required checks can miss verify-only coverage such as privileged execution receipt repair, or let policy drift away from the canonical contract.
 
 ## 2026-04-21
 

--- a/docs/PROJECT_GOVERNANCE.md
+++ b/docs/PROJECT_GOVERNANCE.md
@@ -11,6 +11,14 @@ Playbook requires `docs/PLAYBOOK_NOTES.md` updates so each meaningful change rec
 
 If code paths change (`src/**`, `app/**`, `server/**`, `supabase/**`), update `docs/PLAYBOOK_NOTES.md` in the same change.
 
+## Required merge gate
+
+The canonical hosted merge gate for `main` is the GitHub Actions check run named `verify` from `.github/workflows/ci.yml`.
+
+- Local operators must run `pnpm run verify` before claiming repo-local completion.
+- GitHub branch protection or rulesets for `main` must require the `verify` check, not the manual `Playbook Smoke` workflow.
+- Local verify and hosted verify are intentionally the same contract: `pnpm run verify`.
+
 ## Quick fix for CI failures
 
 If CI fails with `requireNotesOnChanges`:


### PR DESCRIPTION
## Summary
- pin the GitHub Actions job name explicitly to `verify`
- document `pnpm run verify` as the canonical local and hosted merge gate
- record that branch protection for `main` must require `verify`, not `Playbook Smoke`

## Verification
- `pnpm run verify`