### PR TITLE
docs: canary verify gate note

### DIFF
--- a/docs/PLAYBOOK_NOTES.md
+++ b/docs/PLAYBOOK_NOTES.md
@@ -19,6 +19,7 @@ Link related pull requests whenever possible.
   - Prefer one authoritative `verify` entrypoint and one explicit hosted `verify` check over duplicated workflow-specific test lists or ambiguous required-check names.
 - Failure mode addressed:
   - Manually reconstructed workflow gates or mismatched required checks can miss verify-only coverage such as privileged execution receipt repair, or let policy drift away from the canonical contract.
+  - Future canary PRs must stay blocked on `verify` until it passes and must not treat `Playbook Smoke` as a required merge blocker.
 
 ## 2026-04-21
 


### PR DESCRIPTION
## Summary
- add a one-line docs-only canary note in `docs/PLAYBOOK_NOTES.md`
- keep the PR intentionally tiny so the hosted merge gate can be validated against current GitHub config

## Canary checks to confirm
- merge is blocked until `verify` runs and passes
- strict up-to-date behavior remains enabled for `main`
- `Playbook Smoke` is not a required merge blocker

## Verification
- `pnpm run verify`