### PR TITLE
Lifeline: add Wave 1 release mechanics on the existing deploy contract

### DIFF
--- a/control-plane/wave1-deploy-contract.mjs
+++ b/control-plane/wave1-deploy-contract.mjs
@@ -327,6 +327,18 @@ function validateReleaseTarget(target, issues) {
   };
 }
 
+function synthesizeReleaseTarget(value) {
+  if (!isNonEmptyString(value.releaseId) || !isNonEmptyString(value.artifactRef)) {
+    return undefined;
+  }
+
+  return {
+    kind: WAVE1_RELEASE_TARGET_KIND,
+    releaseId: value.releaseId,
+    artifactRef: value.artifactRef,
+  };
+}
+
 function validateRollbackTarget(target, issues) {
   if (!isRecord(target)) {
     pushIssue(issues, "rollbackTarget", "must be an object");
@@ -480,7 +492,10 @@ export function validateWave1ReleaseMetadata(value) {
 
   const migrationHooks = validateHooks(value.migrationHooks, issues);
   const rollbackTarget = validateRollbackTarget(value.rollbackTarget, issues);
-  const releaseTarget = validateReleaseTarget(value.releaseTarget, issues);
+  const releaseTarget =
+    value.releaseTarget === undefined
+      ? synthesizeReleaseTarget(value)
+      : validateReleaseTarget(value.releaseTarget, issues);
 
   if (
     !isRecord(value.validation) ||

--- a/control-plane/wave1-deploy-contract.mjs
+++ b/control-plane/wave1-deploy-contract.mjs
@@ -1,10 +1,19 @@
+import { createHash } from "node:crypto";
+
 export const WAVE1_DEPLOY_CONTRACT_VERSION = "atlas.lifeline.deploy-contract.v1";
 export const WAVE1_RELEASE_METADATA_VERSION =
   "atlas.lifeline.release-metadata.v1";
 export const WAVE1_DRY_RUN_PLAN_VERSION = "atlas.lifeline.deploy-dry-run.v1";
+export const WAVE1_RELEASE_PLAN_VERSION = "atlas.lifeline.release-plan.v1";
 
 export const SUPPORTED_ROLLBACK_STRATEGIES = ["redeploy", "restore"];
 export const SUPPORTED_HOOK_NAMES = ["preDeploy", "postDeploy", "rollback"];
+export const SUPPORTED_SOURCE_ADAPTER_KINDS = [
+  "artifactRef",
+  "imageRef",
+  "branch",
+];
+export const WAVE1_RELEASE_TARGET_KIND = "single-host-immutable";
 
 function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -24,6 +33,35 @@ function pushIssue(issues, path, message) {
 
 function normalizeStringList(value) {
   return [...value];
+}
+
+function stableJsonValue(value) {
+  if (Array.isArray(value)) {
+    return value.map((entry) => stableJsonValue(entry));
+  }
+
+  if (isRecord(value)) {
+    return Object.keys(value)
+      .sort()
+      .reduce((accumulator, key) => {
+        accumulator[key] = stableJsonValue(value[key]);
+        return accumulator;
+      }, {});
+  }
+
+  return value;
+}
+
+function stableJsonStringify(value) {
+  return JSON.stringify(stableJsonValue(value));
+}
+
+function buildBranchArtifactRef(repo, branch) {
+  const normalizedRepo = repo.replace(/#.*$/, "");
+  const prefix = normalizedRepo.startsWith("git+")
+    ? normalizedRepo
+    : `git+${normalizedRepo}`;
+  return `${prefix}#${branch}`;
 }
 
 function validateRoute(route, issues) {
@@ -98,17 +136,195 @@ function validateArtifactRef(manifest, issues) {
   const imageRef = isNonEmptyString(manifest.imageRef)
     ? manifest.imageRef
     : undefined;
+  const repo = isNonEmptyString(manifest.repo) ? manifest.repo : undefined;
+  const branch = isNonEmptyString(manifest.branch) ? manifest.branch : undefined;
 
-  if (!artifactRef && !imageRef) {
+  if ((repo && !branch) || (!repo && branch)) {
     pushIssue(
       issues,
-      "artifactRef",
-      "must be provided as artifactRef or imageRef",
+      !repo ? "repo" : "branch",
+      "repo and branch must be provided together",
     );
     return undefined;
   }
 
-  return artifactRef ?? imageRef;
+  if (!artifactRef && !imageRef && !(repo && branch)) {
+    pushIssue(
+      issues,
+      "artifactRef",
+      "must be provided as artifactRef, imageRef, or repo+branch",
+    );
+    return undefined;
+  }
+
+  if (artifactRef) {
+    return {
+      artifactRef,
+      sourceAdapter: {
+        kind: "artifactRef",
+        artifactRef,
+        canonicalArtifactRef: artifactRef,
+      },
+    };
+  }
+
+  if (imageRef) {
+    return {
+      artifactRef: imageRef,
+      sourceAdapter: {
+        kind: "imageRef",
+        imageRef,
+        canonicalArtifactRef: imageRef,
+      },
+    };
+  }
+
+  const canonicalArtifactRef = buildBranchArtifactRef(repo, branch);
+  return {
+    artifactRef: canonicalArtifactRef,
+    sourceAdapter: {
+      kind: "branch",
+      repo,
+      branch,
+      canonicalArtifactRef,
+    },
+  };
+}
+
+function validateSourceAdapter(adapter, issues) {
+  if (adapter === undefined) {
+    return undefined;
+  }
+
+  if (!isRecord(adapter)) {
+    pushIssue(issues, "sourceAdapter", "must be an object");
+    return undefined;
+  }
+
+  if (
+    !isNonEmptyString(adapter.kind) ||
+    !SUPPORTED_SOURCE_ADAPTER_KINDS.includes(adapter.kind)
+  ) {
+    pushIssue(
+      issues,
+      "sourceAdapter.kind",
+      `must be one of: ${SUPPORTED_SOURCE_ADAPTER_KINDS.join(", ")}`,
+    );
+  }
+
+  if (!isNonEmptyString(adapter.canonicalArtifactRef)) {
+    pushIssue(
+      issues,
+      "sourceAdapter.canonicalArtifactRef",
+      "must be a non-empty string",
+    );
+  }
+
+  if (adapter.kind === "artifactRef") {
+    if (!isNonEmptyString(adapter.artifactRef)) {
+      pushIssue(
+        issues,
+        "sourceAdapter.artifactRef",
+        "must be a non-empty string",
+      );
+    }
+  }
+
+  if (adapter.kind === "imageRef") {
+    if (!isNonEmptyString(adapter.imageRef)) {
+      pushIssue(
+        issues,
+        "sourceAdapter.imageRef",
+        "must be a non-empty string",
+      );
+    }
+  }
+
+  if (adapter.kind === "branch") {
+    if (!isNonEmptyString(adapter.repo)) {
+      pushIssue(issues, "sourceAdapter.repo", "must be a non-empty string");
+    }
+
+    if (!isNonEmptyString(adapter.branch)) {
+      pushIssue(issues, "sourceAdapter.branch", "must be a non-empty string");
+    }
+  }
+
+  if (
+    !isNonEmptyString(adapter.kind) ||
+    !SUPPORTED_SOURCE_ADAPTER_KINDS.includes(adapter.kind) ||
+    !isNonEmptyString(adapter.canonicalArtifactRef)
+  ) {
+    return undefined;
+  }
+
+  if (adapter.kind === "artifactRef" && !isNonEmptyString(adapter.artifactRef)) {
+    return undefined;
+  }
+
+  if (adapter.kind === "imageRef" && !isNonEmptyString(adapter.imageRef)) {
+    return undefined;
+  }
+
+  if (
+    adapter.kind === "branch" &&
+    (!isNonEmptyString(adapter.repo) || !isNonEmptyString(adapter.branch))
+  ) {
+    return undefined;
+  }
+
+  return {
+    kind: adapter.kind,
+    canonicalArtifactRef: adapter.canonicalArtifactRef,
+    ...(adapter.kind === "artifactRef"
+      ? { artifactRef: adapter.artifactRef }
+      : {}),
+    ...(adapter.kind === "imageRef" ? { imageRef: adapter.imageRef } : {}),
+    ...(adapter.kind === "branch"
+      ? { repo: adapter.repo, branch: adapter.branch }
+      : {}),
+  };
+}
+
+function validateReleaseTarget(target, issues) {
+  if (!isRecord(target)) {
+    pushIssue(issues, "releaseTarget", "must be an object");
+    return undefined;
+  }
+
+  if (target.kind !== WAVE1_RELEASE_TARGET_KIND) {
+    pushIssue(
+      issues,
+      "releaseTarget.kind",
+      `must equal ${WAVE1_RELEASE_TARGET_KIND}`,
+    );
+  }
+
+  if (!isNonEmptyString(target.releaseId)) {
+    pushIssue(issues, "releaseTarget.releaseId", "must be a non-empty string");
+  }
+
+  if (!isNonEmptyString(target.artifactRef)) {
+    pushIssue(
+      issues,
+      "releaseTarget.artifactRef",
+      "must be a non-empty string",
+    );
+  }
+
+  if (
+    target.kind !== WAVE1_RELEASE_TARGET_KIND ||
+    !isNonEmptyString(target.releaseId) ||
+    !isNonEmptyString(target.artifactRef)
+  ) {
+    return undefined;
+  }
+
+  return {
+    kind: target.kind,
+    releaseId: target.releaseId,
+    artifactRef: target.artifactRef,
+  };
 }
 
 function validateRollbackTarget(target, issues) {
@@ -177,7 +393,7 @@ export function validateWave1DeployManifest(value) {
     pushIssue(issues, "appName", "must be a non-empty string");
   }
 
-  const artifactRef = validateArtifactRef(value, issues);
+  const artifactInput = validateArtifactRef(value, issues);
   const route = validateRoute(value.route, issues);
   if (value.envRefs === undefined) {
     pushIssue(issues, "envRefs", "must be an array of non-empty strings");
@@ -206,12 +422,15 @@ export function validateWave1DeployManifest(value) {
     manifest: {
       contractVersion: WAVE1_DEPLOY_CONTRACT_VERSION,
       appName: value.appName,
-      artifactRef,
+      artifactRef: artifactInput.artifactRef,
       route,
       envRefs: normalizeStringList(envRefs),
       healthcheckPath: value.healthcheckPath,
       migrationHooks,
       rollbackTarget,
+      ...(artifactInput.sourceAdapter
+        ? { sourceAdapter: artifactInput.sourceAdapter }
+        : {}),
     },
   };
 }
@@ -245,6 +464,8 @@ export function validateWave1ReleaseMetadata(value) {
     pushIssue(issues, "artifactRef", "must be a non-empty string");
   }
 
+  const sourceAdapter = validateSourceAdapter(value.sourceAdapter, issues);
+
   const route = validateRoute(value.route, issues);
 
   if (!isStringArray(value.envRefs)) {
@@ -259,6 +480,7 @@ export function validateWave1ReleaseMetadata(value) {
 
   const migrationHooks = validateHooks(value.migrationHooks, issues);
   const rollbackTarget = validateRollbackTarget(value.rollbackTarget, issues);
+  const releaseTarget = validateReleaseTarget(value.releaseTarget, issues);
 
   if (
     !isRecord(value.validation) ||
@@ -313,6 +535,8 @@ export function validateWave1ReleaseMetadata(value) {
       healthcheckPath: value.healthcheckPath,
       migrationHooks,
       rollbackTarget,
+      ...(sourceAdapter ? { sourceAdapter } : {}),
+      releaseTarget,
       dryRun: value.dryRun,
       createdAt: value.createdAt,
       validation: {
@@ -326,9 +550,79 @@ export function validateWave1ReleaseMetadata(value) {
   };
 }
 
+export function deriveWave1ReleaseId(manifest) {
+  const validation = validateWave1DeployManifest(manifest);
+  if (validation.issues.length > 0 || !validation.manifest) {
+    return undefined;
+  }
+
+  const hash = createHash("sha256")
+    .update(
+      stableJsonStringify({
+        appName: validation.manifest.appName,
+        artifactRef: validation.manifest.artifactRef,
+        route: validation.manifest.route,
+        envRefs: validation.manifest.envRefs,
+        healthcheckPath: validation.manifest.healthcheckPath,
+        migrationHooks: validation.manifest.migrationHooks,
+      }),
+    )
+    .digest("hex")
+    .slice(0, 16);
+
+  return `release-${validation.manifest.appName}-${hash}`;
+}
+
+export function buildWave1ReleaseMetadata(manifest, options) {
+  const validation = validateWave1DeployManifest(manifest);
+  const releaseId = options?.releaseId ?? deriveWave1ReleaseId(manifest);
+  const createdAt = options?.createdAt ?? "1970-01-01T00:00:00.000Z";
+  const dryRun = options?.dryRun ?? false;
+
+  if (
+    validation.issues.length > 0 ||
+    !validation.manifest ||
+    !isNonEmptyString(releaseId)
+  ) {
+    return {
+      issues: validation.issues,
+      metadata: undefined,
+    };
+  }
+
+  return {
+    issues: [],
+    metadata: {
+      contractVersion: WAVE1_RELEASE_METADATA_VERSION,
+      releaseId,
+      appName: validation.manifest.appName,
+      artifactRef: validation.manifest.artifactRef,
+      route: validation.manifest.route,
+      envRefs: validation.manifest.envRefs,
+      healthcheckPath: validation.manifest.healthcheckPath,
+      migrationHooks: validation.manifest.migrationHooks,
+      rollbackTarget: validation.manifest.rollbackTarget,
+      ...(validation.manifest.sourceAdapter
+        ? { sourceAdapter: validation.manifest.sourceAdapter }
+        : {}),
+      releaseTarget: {
+        kind: WAVE1_RELEASE_TARGET_KIND,
+        releaseId,
+        artifactRef: validation.manifest.artifactRef,
+      },
+      dryRun,
+      createdAt,
+      validation: {
+        status: "passed",
+        issues: [],
+      },
+    },
+  };
+}
+
 export function buildWave1DryRunPlan(manifest, options) {
   const validation = validateWave1DeployManifest(manifest);
-  const releaseId = options?.releaseId ?? "wave1-dry-run-release";
+  const releaseId = options?.releaseId ?? deriveWave1ReleaseId(manifest);
   const createdAt = options?.createdAt ?? "1970-01-01T00:00:00.000Z";
 
   if (validation.issues.length > 0 || !validation.manifest) {
@@ -353,23 +647,12 @@ export function buildWave1DryRunPlan(manifest, options) {
     };
   }
 
-  const releaseMetadata = {
-    contractVersion: WAVE1_RELEASE_METADATA_VERSION,
+  const builtReleaseMetadata = buildWave1ReleaseMetadata(manifest, {
     releaseId,
-    appName: validation.manifest.appName,
-    artifactRef: validation.manifest.artifactRef,
-    route: validation.manifest.route,
-    envRefs: validation.manifest.envRefs,
-    healthcheckPath: validation.manifest.healthcheckPath,
-    migrationHooks: validation.manifest.migrationHooks,
-    rollbackTarget: validation.manifest.rollbackTarget,
-    dryRun: true,
     createdAt,
-    validation: {
-      status: "passed",
-      issues: [],
-    },
-  };
+    dryRun: true,
+  });
+  const releaseMetadata = builtReleaseMetadata.metadata;
 
   return {
     contractVersion: WAVE1_DRY_RUN_PLAN_VERSION,
@@ -384,12 +667,20 @@ export function buildWave1DryRunPlan(manifest, options) {
       {
         step: "canonicalize-artifact-ref",
         status: "passed",
-        detail: "artifactRef is ready for persistence",
+        detail:
+          validation.manifest.sourceAdapter?.kind === "branch"
+            ? "repo+branch input canonicalized to artifactRef for persistence"
+            : "artifactRef is ready for persistence",
       },
       {
         step: "prepare-release-metadata",
         status: "passed",
         detail: "release metadata preview is ready",
+      },
+      {
+        step: "derive-release-target",
+        status: "passed",
+        detail: "release target is pinned to a concrete release id",
       },
       {
         step: "preserve-rollback-target",
@@ -402,6 +693,85 @@ export function buildWave1DryRunPlan(manifest, options) {
       issues: [],
     },
     releaseMetadata,
+  };
+}
+
+export function buildWave1ReleasePlan(manifest, options) {
+  const validation = validateWave1DeployManifest(manifest);
+  const releaseId = options?.releaseId ?? deriveWave1ReleaseId(manifest);
+  const createdAt = options?.createdAt ?? "1970-01-01T00:00:00.000Z";
+  const builtReleaseMetadata = buildWave1ReleaseMetadata(manifest, {
+    releaseId,
+    createdAt,
+    dryRun: false,
+  });
+
+  if (
+    validation.issues.length > 0 ||
+    !validation.manifest ||
+    !builtReleaseMetadata.metadata
+  ) {
+    return {
+      contractVersion: WAVE1_RELEASE_PLAN_VERSION,
+      releaseId: releaseId ?? "invalid-release",
+      appName:
+        isRecord(manifest) && isNonEmptyString(manifest.appName)
+          ? manifest.appName
+          : "unknown",
+      steps: [
+        {
+          step: "validate-manifest",
+          status: "failed",
+          detail: "validation failed before release planning",
+        },
+      ],
+      validation: {
+        status: "failed",
+        issues: validation.issues,
+      },
+      releaseMetadata: null,
+    };
+  }
+
+  return {
+    contractVersion: WAVE1_RELEASE_PLAN_VERSION,
+    releaseId,
+    appName: validation.manifest.appName,
+    steps: [
+      {
+        step: "validate-manifest",
+        status: "passed",
+        detail: "deploy manifest is valid",
+      },
+      {
+        step: "canonicalize-artifact-ref",
+        status: "passed",
+        detail:
+          validation.manifest.sourceAdapter?.kind === "branch"
+            ? "repo+branch input canonicalized to artifactRef for persistence"
+            : "artifactRef is ready for immutable release staging",
+      },
+      {
+        step: "derive-release-id",
+        status: "passed",
+        detail: "release id is deterministic for the normalized release target",
+      },
+      {
+        step: "derive-release-target",
+        status: "passed",
+        detail: "release target is pinned to a concrete immutable release id",
+      },
+      {
+        step: "preserve-rollback-target",
+        status: "passed",
+        detail: "rollback target metadata is preserved for activation and rollback",
+      },
+    ],
+    validation: {
+      status: "passed",
+      issues: [],
+    },
+    releaseMetadata: builtReleaseMetadata.metadata,
   };
 }
 

--- a/control-plane/wave1-release-engine.mjs
+++ b/control-plane/wave1-release-engine.mjs
@@ -1,0 +1,530 @@
+import { createHash } from "node:crypto";
+import { access, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  buildWave1ReleasePlan,
+  parseWave1ReleaseMetadata,
+  serializeWave1ReleaseMetadata,
+} from "./wave1-deploy-contract.mjs";
+
+export const WAVE1_RELEASE_POINTER_VERSION =
+  "atlas.lifeline.release-pointer.v1";
+export const WAVE1_RELEASE_RECEIPT_VERSION =
+  "atlas.lifeline.release-receipt.v1";
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stableJsonValue(value) {
+  if (Array.isArray(value)) {
+    return value.map((entry) => stableJsonValue(entry));
+  }
+
+  if (isRecord(value)) {
+    return Object.keys(value)
+      .sort()
+      .reduce((accumulator, key) => {
+        accumulator[key] = stableJsonValue(value[key]);
+        return accumulator;
+      }, {});
+  }
+
+  return value;
+}
+
+function stableJsonStringify(value) {
+  return JSON.stringify(stableJsonValue(value), null, 2);
+}
+
+function normalizePath(filePath) {
+  return filePath.replace(/\\/g, "/");
+}
+
+function normalizeRelativePath(rootDir, filePath) {
+  return normalizePath(path.relative(rootDir, filePath));
+}
+
+function releaseRoot(rootDir) {
+  return path.join(rootDir, ".lifeline", "releases");
+}
+
+function appReleaseRoot(rootDir, appName) {
+  return path.join(releaseRoot(rootDir), appName);
+}
+
+function releaseDirectory(rootDir, appName, releaseId) {
+  return path.join(appReleaseRoot(rootDir, appName), releaseId);
+}
+
+function releaseMetadataPath(rootDir, appName, releaseId) {
+  return path.join(releaseDirectory(rootDir, appName, releaseId), "metadata.json");
+}
+
+function currentPointerPath(rootDir, appName) {
+  return path.join(appReleaseRoot(rootDir, appName), "current.json");
+}
+
+function previousPointerPath(rootDir, appName) {
+  return path.join(appReleaseRoot(rootDir, appName), "previous.json");
+}
+
+function receiptsDirectory(rootDir, appName) {
+  return path.join(appReleaseRoot(rootDir, appName), "receipts");
+}
+
+function deriveReceiptId(payload) {
+  return createHash("sha256")
+    .update(stableJsonStringify(payload))
+    .digest("hex")
+    .slice(0, 16);
+}
+
+async function pathExists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeStableJson(filePath, payload) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${stableJsonStringify(payload)}\n`, "utf8");
+}
+
+async function writeImmutableJson(filePath, payload) {
+  if (await pathExists(filePath)) {
+    const existing = await readFile(filePath, "utf8");
+    const next = `${stableJsonStringify(payload)}\n`;
+    if (existing !== next) {
+      throw new Error(`Refusing to rewrite immutable release file: ${filePath}`);
+    }
+    return;
+  }
+
+  await writeStableJson(filePath, payload);
+}
+
+async function readPointer(filePath) {
+  const raw = await readFile(filePath, "utf8").catch(() => "");
+  if (!raw) {
+    return undefined;
+  }
+
+  const parsed = JSON.parse(raw);
+  if (
+    !isRecord(parsed) ||
+    parsed.contractVersion !== WAVE1_RELEASE_POINTER_VERSION ||
+    typeof parsed.appName !== "string" ||
+    typeof parsed.releaseId !== "string" ||
+    typeof parsed.updatedAt !== "string"
+  ) {
+    throw new Error(`Invalid release pointer at ${filePath}`);
+  }
+
+  return parsed;
+}
+
+async function writePointer(filePath, payload) {
+  await writeStableJson(filePath, payload);
+}
+
+async function clearPointer(filePath) {
+  await unlink(filePath).catch(() => undefined);
+}
+
+async function loadReleaseMetadata(rootDir, appName, releaseId) {
+  const metadataFilePath = releaseMetadataPath(rootDir, appName, releaseId);
+  const parsed = parseWave1ReleaseMetadata(
+    await readFile(metadataFilePath, "utf8"),
+  );
+
+  if (parsed.issues.length > 0 || !parsed.metadata) {
+    throw new Error(
+      `Invalid release metadata at ${metadataFilePath}: ${JSON.stringify(parsed.issues)}`,
+    );
+  }
+
+  return {
+    metadata: parsed.metadata,
+    metadataFilePath,
+  };
+}
+
+async function writeReceipt(rootDir, appName, payload) {
+  const receiptId = payload.receiptId ?? deriveReceiptId(payload);
+  const fullPayload = {
+    ...payload,
+    contractVersion: WAVE1_RELEASE_RECEIPT_VERSION,
+    receiptId,
+  };
+  const receiptPath = path.join(receiptsDirectory(rootDir, appName), `${receiptId}.json`);
+  await writeImmutableJson(receiptPath, fullPayload);
+  return {
+    receiptId,
+    receiptPath,
+    receipt: fullPayload,
+  };
+}
+
+export function getWave1ReleaseLayout(rootDir, appName, releaseId) {
+  const metadataPath = releaseMetadataPath(rootDir, appName, releaseId);
+  const releaseDir = releaseDirectory(rootDir, appName, releaseId);
+
+  return {
+    releaseRoot: releaseRoot(rootDir),
+    appReleaseRoot: appReleaseRoot(rootDir, appName),
+    releaseDirectory: releaseDir,
+    releaseMetadataPath: metadataPath,
+    currentPointerPath: currentPointerPath(rootDir, appName),
+    previousPointerPath: previousPointerPath(rootDir, appName),
+    receiptsDirectory: receiptsDirectory(rootDir, appName),
+  };
+}
+
+export function getWave1ReleaseStatePaths(rootDir, appName) {
+  return {
+    currentPointerPath: currentPointerPath(rootDir, appName),
+    previousPointerPath: previousPointerPath(rootDir, appName),
+    receiptsDirectory: receiptsDirectory(rootDir, appName),
+  };
+}
+
+export async function readWave1ReleaseState(rootDir, appName) {
+  return {
+    current: await readPointer(currentPointerPath(rootDir, appName)),
+    previous: await readPointer(previousPointerPath(rootDir, appName)),
+  };
+}
+
+export function planWave1Release(manifest, options = {}) {
+  const releasePlan = buildWave1ReleasePlan(manifest, options);
+  if (!releasePlan.releaseMetadata) {
+    return releasePlan;
+  }
+
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const layout = getWave1ReleaseLayout(
+    rootDir,
+    releasePlan.appName,
+    releasePlan.releaseId,
+  );
+
+  return {
+    ...releasePlan,
+    rootDir: normalizePath(rootDir),
+    layout: {
+      releaseDirectory: normalizeRelativePath(rootDir, layout.releaseDirectory),
+      releaseMetadataPath: normalizeRelativePath(rootDir, layout.releaseMetadataPath),
+      currentPointerPath: normalizeRelativePath(rootDir, layout.currentPointerPath),
+      previousPointerPath: normalizeRelativePath(rootDir, layout.previousPointerPath),
+      receiptsDirectory: normalizeRelativePath(rootDir, layout.receiptsDirectory),
+    },
+  };
+}
+
+export async function persistWave1Release(manifest, options = {}) {
+  const releasePlan = planWave1Release(manifest, options);
+  if (!releasePlan.releaseMetadata) {
+    return releasePlan;
+  }
+
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const layout = getWave1ReleaseLayout(
+    rootDir,
+    releasePlan.appName,
+    releasePlan.releaseId,
+  );
+  await mkdir(layout.releaseDirectory, { recursive: true });
+  await mkdir(layout.receiptsDirectory, { recursive: true });
+  await writeImmutableJson(
+    layout.releaseMetadataPath,
+    JSON.parse(serializeWave1ReleaseMetadata(releasePlan.releaseMetadata)),
+  );
+
+  const receiptAt =
+    options.receiptAt ?? releasePlan.releaseMetadata.createdAt;
+  const receiptResult = await writeReceipt(rootDir, releasePlan.appName, {
+    action: "planned",
+    status: "planned",
+    appName: releasePlan.appName,
+    releaseId: releasePlan.releaseId,
+    createdAt: receiptAt,
+    releaseDirectory: releasePlan.layout.releaseDirectory,
+    releaseMetadataPath: releasePlan.layout.releaseMetadataPath,
+    currentPointerPath: releasePlan.layout.currentPointerPath,
+    previousPointerPath: releasePlan.layout.previousPointerPath,
+    releaseTarget: releasePlan.releaseMetadata.releaseTarget,
+    rollbackTarget: releasePlan.releaseMetadata.rollbackTarget,
+    sourceAdapter: releasePlan.releaseMetadata.sourceAdapter,
+  });
+
+  return {
+    ...releasePlan,
+    receipt: {
+      ...receiptResult.receipt,
+      receiptPath: normalizeRelativePath(rootDir, receiptResult.receiptPath),
+    },
+  };
+}
+
+export async function activateWave1Release(
+  rootDir,
+  appName,
+  releaseId,
+  options = {},
+) {
+  const resolvedRoot = path.resolve(rootDir);
+  const layout = getWave1ReleaseLayout(resolvedRoot, appName, releaseId);
+  const { metadata } = await loadReleaseMetadata(resolvedRoot, appName, releaseId);
+  const current = await readPointer(layout.currentPointerPath);
+  const previous = await readPointer(layout.previousPointerPath);
+  const health =
+    (await options.checkHealth?.({
+      metadata,
+      current,
+      previous,
+    })) ?? { ok: true, status: 200 };
+  const receiptAt = options.receiptAt ?? metadata.createdAt;
+
+  if (!health.ok) {
+    const failedReceipt = await writeReceipt(resolvedRoot, appName, {
+      action: "activate",
+      status: "failed",
+      appName,
+      releaseId,
+      previousReleaseId: current?.releaseId,
+      createdAt: receiptAt,
+      releaseDirectory: normalizeRelativePath(resolvedRoot, layout.releaseDirectory),
+      releaseMetadataPath: normalizeRelativePath(
+        resolvedRoot,
+        layout.releaseMetadataPath,
+      ),
+      currentPointerPath: normalizeRelativePath(
+        resolvedRoot,
+        layout.currentPointerPath,
+      ),
+      previousPointerPath: normalizeRelativePath(
+        resolvedRoot,
+        layout.previousPointerPath,
+      ),
+      releaseTarget: metadata.releaseTarget,
+      rollbackTarget: metadata.rollbackTarget,
+      health,
+      preservedCurrentReleaseId: current?.releaseId,
+      preservedPreviousReleaseId: previous?.releaseId,
+    });
+
+    return {
+      ok: false,
+      health,
+      current,
+      previous,
+      receipt: {
+        ...failedReceipt.receipt,
+        receiptPath: normalizeRelativePath(resolvedRoot, failedReceipt.receiptPath),
+      },
+    };
+  }
+
+  const nextPrevious = current && current.releaseId !== releaseId
+    ? {
+        contractVersion: WAVE1_RELEASE_POINTER_VERSION,
+        appName,
+        releaseId: current.releaseId,
+        updatedAt: receiptAt,
+        reason: "activation",
+      }
+    : previous;
+  const nextCurrent = {
+    contractVersion: WAVE1_RELEASE_POINTER_VERSION,
+    appName,
+    releaseId,
+    updatedAt: receiptAt,
+    reason: "activation",
+  };
+
+  await writePointer(layout.currentPointerPath, nextCurrent);
+  if (nextPrevious) {
+    await writePointer(layout.previousPointerPath, nextPrevious);
+  } else {
+    await clearPointer(layout.previousPointerPath);
+  }
+
+  const activationReceipt = await writeReceipt(resolvedRoot, appName, {
+    action: "activate",
+    status: "succeeded",
+    appName,
+    releaseId,
+    previousReleaseId: current?.releaseId,
+    createdAt: receiptAt,
+    releaseDirectory: normalizeRelativePath(resolvedRoot, layout.releaseDirectory),
+    releaseMetadataPath: normalizeRelativePath(
+      resolvedRoot,
+      layout.releaseMetadataPath,
+    ),
+    currentPointerPath: normalizeRelativePath(
+      resolvedRoot,
+      layout.currentPointerPath,
+    ),
+    previousPointerPath: normalizeRelativePath(
+      resolvedRoot,
+      layout.previousPointerPath,
+    ),
+    releaseTarget: metadata.releaseTarget,
+    rollbackTarget: metadata.rollbackTarget,
+    health,
+    lineage: {
+      promotedFromReleaseId: current?.releaseId,
+      promotedToReleaseId: releaseId,
+    },
+  });
+
+  return {
+    ok: true,
+    health,
+    current: nextCurrent,
+    previous: nextPrevious,
+    receipt: {
+      ...activationReceipt.receipt,
+      receiptPath: normalizeRelativePath(resolvedRoot, activationReceipt.receiptPath),
+    },
+  };
+}
+
+export async function rollbackWave1Release(rootDir, appName, options = {}) {
+  const resolvedRoot = path.resolve(rootDir);
+  const current = await readPointer(currentPointerPath(resolvedRoot, appName));
+  const previous = await readPointer(previousPointerPath(resolvedRoot, appName));
+
+  if (!current || !previous) {
+    throw new Error(
+      `Rollback requires both current and previous releases for ${appName}.`,
+    );
+  }
+
+  const targetLayout = getWave1ReleaseLayout(
+    resolvedRoot,
+    appName,
+    previous.releaseId,
+  );
+  const { metadata } = await loadReleaseMetadata(
+    resolvedRoot,
+    appName,
+    previous.releaseId,
+  );
+  const health =
+    (await options.checkHealth?.({
+      metadata,
+      current,
+      previous,
+    })) ?? { ok: true, status: 200 };
+  const receiptAt = options.receiptAt ?? metadata.createdAt;
+
+  if (!health.ok) {
+    const failedReceipt = await writeReceipt(resolvedRoot, appName, {
+      action: "rollback",
+      status: "failed",
+      appName,
+      releaseId: previous.releaseId,
+      previousReleaseId: current.releaseId,
+      createdAt: receiptAt,
+      releaseDirectory: normalizeRelativePath(
+        resolvedRoot,
+        targetLayout.releaseDirectory,
+      ),
+      releaseMetadataPath: normalizeRelativePath(
+        resolvedRoot,
+        targetLayout.releaseMetadataPath,
+      ),
+      currentPointerPath: normalizeRelativePath(
+        resolvedRoot,
+        targetLayout.currentPointerPath,
+      ),
+      previousPointerPath: normalizeRelativePath(
+        resolvedRoot,
+        targetLayout.previousPointerPath,
+      ),
+      releaseTarget: metadata.releaseTarget,
+      rollbackTarget: metadata.rollbackTarget,
+      health,
+      preservedCurrentReleaseId: current.releaseId,
+      preservedPreviousReleaseId: previous.releaseId,
+    });
+
+    return {
+      ok: false,
+      health,
+      current,
+      previous,
+      receipt: {
+        ...failedReceipt.receipt,
+        receiptPath: normalizeRelativePath(resolvedRoot, failedReceipt.receiptPath),
+      },
+    };
+  }
+
+  const nextCurrent = {
+    contractVersion: WAVE1_RELEASE_POINTER_VERSION,
+    appName,
+    releaseId: previous.releaseId,
+    updatedAt: receiptAt,
+    reason: "rollback",
+  };
+  const nextPrevious = {
+    contractVersion: WAVE1_RELEASE_POINTER_VERSION,
+    appName,
+    releaseId: current.releaseId,
+    updatedAt: receiptAt,
+    reason: "rollback",
+  };
+
+  await writePointer(targetLayout.currentPointerPath, nextCurrent);
+  await writePointer(targetLayout.previousPointerPath, nextPrevious);
+
+  const rollbackReceipt = await writeReceipt(resolvedRoot, appName, {
+    action: "rollback",
+    status: "succeeded",
+    appName,
+    releaseId: previous.releaseId,
+    previousReleaseId: current.releaseId,
+    createdAt: receiptAt,
+    releaseDirectory: normalizeRelativePath(
+      resolvedRoot,
+      targetLayout.releaseDirectory,
+    ),
+    releaseMetadataPath: normalizeRelativePath(
+      resolvedRoot,
+      targetLayout.releaseMetadataPath,
+    ),
+    currentPointerPath: normalizeRelativePath(
+      resolvedRoot,
+      targetLayout.currentPointerPath,
+    ),
+    previousPointerPath: normalizeRelativePath(
+      resolvedRoot,
+      targetLayout.previousPointerPath,
+    ),
+    releaseTarget: metadata.releaseTarget,
+    rollbackTarget: metadata.rollbackTarget,
+    health,
+    lineage: {
+      promotedFromReleaseId: current.releaseId,
+      promotedToReleaseId: previous.releaseId,
+    },
+  });
+
+  return {
+    ok: true,
+    health,
+    current: nextCurrent,
+    previous: nextPrevious,
+    receipt: {
+      ...rollbackReceipt.receipt,
+      receiptPath: normalizeRelativePath(resolvedRoot, rollbackReceipt.receiptPath),
+    },
+  };
+}

--- a/control-plane/wave1-release-engine.mjs
+++ b/control-plane/wave1-release-engine.mjs
@@ -54,12 +54,73 @@ function appReleaseRoot(rootDir, appName) {
   return path.join(releaseRoot(rootDir), appName);
 }
 
+function hasPathEscape(relativePath) {
+  return (
+    relativePath === ".." ||
+    relativePath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativePath)
+  );
+}
+
+function assertPathWithinRoot(rootPath, candidatePath, label) {
+  const relativePath = path.relative(rootPath, candidatePath);
+  if (relativePath === "" || !hasPathEscape(relativePath)) {
+    return candidatePath;
+  }
+
+  throw new Error(`${label} must stay within ${rootPath}`);
+}
+
+function validateReleaseId(releaseId) {
+  if (typeof releaseId !== "string" || releaseId.trim().length === 0) {
+    throw new Error("Release id must be a non-empty string.");
+  }
+
+  if (path.isAbsolute(releaseId)) {
+    throw new Error(`Invalid releaseId "${releaseId}": absolute paths are not allowed.`);
+  }
+
+  if (releaseId.includes("/") || releaseId.includes("\\")) {
+    throw new Error(
+      `Invalid releaseId "${releaseId}": path separators are not allowed.`,
+    );
+  }
+
+  if (releaseId === "." || releaseId === "..") {
+    throw new Error(
+      `Invalid releaseId "${releaseId}": dot-segment values are not allowed.`,
+    );
+  }
+
+  return releaseId;
+}
+
+function resolveReleaseScopedPath(rootDir, appName, releaseId, ...segments) {
+  const appRoot = path.resolve(appReleaseRoot(rootDir, appName));
+  const validatedReleaseId = validateReleaseId(releaseId);
+  const releaseDir = assertPathWithinRoot(
+    appRoot,
+    path.resolve(appRoot, validatedReleaseId),
+    `Release directory for ${appName}/${releaseId}`,
+  );
+
+  if (segments.length === 0) {
+    return releaseDir;
+  }
+
+  return assertPathWithinRoot(
+    appRoot,
+    path.resolve(releaseDir, ...segments),
+    `Release path for ${appName}/${releaseId}`,
+  );
+}
+
 function releaseDirectory(rootDir, appName, releaseId) {
-  return path.join(appReleaseRoot(rootDir, appName), releaseId);
+  return resolveReleaseScopedPath(rootDir, appName, releaseId);
 }
 
 function releaseMetadataPath(rootDir, appName, releaseId) {
-  return path.join(releaseDirectory(rootDir, appName, releaseId), "metadata.json");
+  return resolveReleaseScopedPath(rootDir, appName, releaseId, "metadata.json");
 }
 
 function currentPointerPath(rootDir, appName) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,7 +67,20 @@ Runtime behavior:
 
 Logs remain file-based at `.lifeline/logs/<app>.log` and include both app output and supervisor lifecycle events.
 
-## 6. Receipt-backed execution and proof surfaces
+## 6. Wave 1 release target surface
+
+Wave 1 release planning and activation stay local-first:
+
+- the deploy contract normalizes `artifactRef`, `imageRef`, and branch-shaped `repo` + `branch` inputs into one canonical release target
+- release ids are deterministic from the normalized release target unless an operator pins a specific id
+- immutable release metadata lands at `.lifeline/releases/<app>/<releaseId>/metadata.json`
+- mutable activation state is limited to `current.json` and `previous.json`
+- activation is health-gated, and failed candidates must not disturb the last known-good release pointers
+- plan, activation, failed activation, and rollback each emit receipts keyed to concrete release ids
+
+This is the first execution slice that replaces "deploy a branch" with "deploy a concrete release target" without introducing hosted control-plane behavior.
+
+## 7. Receipt-backed execution and proof surfaces
 
 Lifeline exposes two narrow auditable lanes after validation/runtime work:
 

--- a/docs/contracts/wave1-deploy-contract.md
+++ b/docs/contracts/wave1-deploy-contract.md
@@ -14,7 +14,7 @@ The deploy manifest is a JSON object with:
 
 - `contractVersion`
 - `appName`
-- `artifactRef` or `imageRef`
+- `artifactRef`, `imageRef`, or `repo` + `branch`
 - `route.domain`
 - `route.path` when the route is not rooted
 - `envRefs`
@@ -26,19 +26,26 @@ The deploy manifest is a JSON object with:
 - `rollbackTarget.artifactRef`
 - `rollbackTarget.strategy`
 
-Canonical validation accepts `artifactRef` or `imageRef` on input and normalizes to `artifactRef` for downstream use.
+Canonical validation accepts `artifactRef`, `imageRef`, or a branch-shaped `repo` + `branch` input and normalizes all of them to `artifactRef` for downstream use.
 
 ## Release metadata shape
 
 Release metadata is the persisted record ops and rollback tooling consume after a deploy decision. It keeps the normalized deploy contract plus:
 
 - `releaseId`
+- `releaseTarget.kind`
+- `releaseTarget.releaseId`
+- `releaseTarget.artifactRef`
+- `sourceAdapter.kind` when a compatibility adapter was used
 - `dryRun`
 - `createdAt`
 - `validation.status`
 - `validation.issues`
 
-The persisted metadata stays JSON only, with no runtime-only state embedded.
+`releaseId` is deterministic from the normalized release target unless a caller intentionally pins it. `releaseTarget` is the concrete Wave 1 handoff surface for downstream consumers: a single-host immutable release identified by `releaseId` and `artifactRef`.
+When the input arrived as `imageRef` or `repo` + `branch`, Lifeline preserves that fact in `sourceAdapter` while still normalizing the persisted release target to `artifactRef`.
+
+The persisted metadata stays JSON only, with no hosted control-plane state embedded.
 
 ## Dry-run path
 
@@ -47,12 +54,26 @@ The dry-run path is a pure planning path:
 1. validate the deploy manifest
 2. canonicalize `artifactRef`
 3. assemble release metadata
-4. preserve rollback target metadata unchanged
+4. derive the concrete release target
+5. preserve rollback target metadata unchanged
 
 Dry-run planning must not mutate the input manifest or write state. It only emits a plan object and a release metadata preview.
+
+## Immutable single-host release engine
+
+Wave 1 release execution is local-first and single-host:
+
+- each release is persisted once at `.lifeline/releases/<app>/<releaseId>/metadata.json`
+- release directories are immutable after the metadata lands
+- mutable activation state lives only in `.lifeline/releases/<app>/current.json` and `previous.json`
+- activation is health-gated before the current pointer advances
+- failed health gates preserve the existing current and previous release pointers
+- rollback promotes the previous known-good release back to current
+- plan, activation, failed activation, and rollback each emit a receipt under `.lifeline/releases/<app>/receipts/`
+
+This keeps the durable release target explicit without widening Lifeline into preview URLs, hosted control-plane behavior, domains, or TLS management.
 
 ## Schema files
 
 - [`../../schemas/wave1-deploy-contract.schema.json`](../../schemas/wave1-deploy-contract.schema.json)
 - [`../../schemas/wave1-release-metadata.schema.json`](../../schemas/wave1-release-metadata.schema.json)
-

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "verify": "pnpm typecheck && pnpm build && pnpm test:privileged-execution-bridge && pnpm test:privileged-execution-repair && pnpm test:ui-proof-receipt",
+    "verify": "pnpm typecheck && pnpm build && pnpm test:wave1-deploy-contract && pnpm test:wave1-release-mechanics && pnpm test:privileged-execution-bridge && pnpm test:privileged-execution-repair && pnpm test:ui-proof-receipt",
     "check": "biome check .",
     "format": "biome format --write .",
     "validate:fitness": "node dist/cli.js validate examples/fitness-app.lifeline.yml",
@@ -61,6 +61,8 @@
     "smoke:runtime:up-missing-env-file": "node scripts/smoke-runtime-up-missing-env-file.mjs",
     "smoke:runtime:up-malformed-env-file": "node scripts/smoke-runtime-up-malformed-env-file.mjs",
     "smoke:runtime:restore-missing-env-file": "node scripts/smoke-runtime-restore-missing-env-file.mjs",
+    "test:wave1-deploy-contract": "node tests/contracts/test-wave1-deploy-contract-deterministic.mjs",
+    "test:wave1-release-mechanics": "node scripts/test-wave1-release-mechanics-deterministic.mjs",
     "test:startup-deterministic": "node scripts/test-wave2-startup-deterministic.mjs",
     "test:startup-roundtrip": "node scripts/test-startup-roundtrip-windows-deterministic.mjs",
     "test:privileged-execution-bridge": "node scripts/test-privileged-execution-worker-bridge-deterministic.mjs",

--- a/schemas/wave1-deploy-contract.schema.json
+++ b/schemas/wave1-deploy-contract.schema.json
@@ -20,6 +20,14 @@
       "type": "string",
       "minLength": 1
     },
+    "repo": {
+      "type": "string",
+      "minLength": 1
+    },
+    "branch": {
+      "type": "string",
+      "minLength": 1
+    },
     "artifactRef": {
       "type": "string",
       "minLength": 1
@@ -129,6 +137,12 @@
     {
       "required": [
         "imageRef"
+      ]
+    },
+    {
+      "required": [
+        "repo",
+        "branch"
       ]
     }
   ],

--- a/schemas/wave1-release-metadata.schema.json
+++ b/schemas/wave1-release-metadata.schema.json
@@ -13,6 +13,7 @@
     "healthcheckPath",
     "migrationHooks",
     "rollbackTarget",
+    "releaseTarget",
     "dryRun",
     "createdAt",
     "validation"
@@ -118,6 +119,65 @@
           ]
         },
         "note": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "sourceAdapter": {
+      "type": "object",
+      "required": [
+        "kind",
+        "canonicalArtifactRef"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "artifactRef",
+            "imageRef",
+            "branch"
+          ]
+        },
+        "canonicalArtifactRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "artifactRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "imageRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repo": {
+          "type": "string",
+          "minLength": 1
+        },
+        "branch": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "releaseTarget": {
+      "type": "object",
+      "required": [
+        "kind",
+        "releaseId",
+        "artifactRef"
+      ],
+      "properties": {
+        "kind": {
+          "const": "single-host-immutable"
+        },
+        "releaseId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "artifactRef": {
           "type": "string",
           "minLength": 1
         }

--- a/scripts/test-wave1-release-mechanics-deterministic.mjs
+++ b/scripts/test-wave1-release-mechanics-deterministic.mjs
@@ -1,8 +1,12 @@
 import { strict as assert } from "node:assert";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import {
+  buildWave1ReleaseMetadata,
+  serializeWave1ReleaseMetadata,
+} from "../control-plane/wave1-deploy-contract.mjs";
 import {
   activateWave1Release,
   persistWave1Release,
@@ -43,12 +47,52 @@ async function readJson(rootDir, relativePath) {
   return JSON.parse(await readFile(path.join(rootDir, relativePath), "utf8"));
 }
 
+async function pathExists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeLegacyReleaseMetadata(rootDir, manifest, options) {
+  const builtMetadata = buildWave1ReleaseMetadata(manifest, options);
+  assert.equal(
+    builtMetadata.issues.length,
+    0,
+    `unexpected legacy metadata build issues: ${JSON.stringify(builtMetadata.issues)}`,
+  );
+
+  const legacyMetadata = {
+    ...builtMetadata.metadata,
+  };
+  delete legacyMetadata.releaseTarget;
+
+  const releaseDir = path.join(
+    rootDir,
+    ".lifeline",
+    "releases",
+    legacyMetadata.appName,
+    legacyMetadata.releaseId,
+  );
+  await mkdir(releaseDir, { recursive: true });
+  await writeFile(
+    path.join(releaseDir, "metadata.json"),
+    `${serializeWave1ReleaseMetadata(legacyMetadata)}\n`,
+    "utf8",
+  );
+
+  return legacyMetadata;
+}
+
 const tempRoot = await mkdtemp(
   path.join(os.tmpdir(), "lifeline-release-mechanics-"),
 );
 
 try {
   const appName = "lifeline-pilot";
+  const outsidePath = path.join(tempRoot, ".lifeline", "outside");
 
   const releaseA = await persistWave1Release(
     createManifest({
@@ -76,6 +120,46 @@ try {
     releaseA.receipt.releaseDirectory,
     ".lifeline/releases/lifeline-pilot/release-20260425-0001",
   );
+
+  await assert.rejects(
+    persistWave1Release(
+      createManifest({
+        appName,
+        artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        rollbackReleaseId: "bootstrap-release",
+        rollbackArtifactRef:
+          "ghcr.io/fawxzzy/lifeline-pilot@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      }),
+      {
+        rootDir: tempRoot,
+        releaseId: "../../outside",
+        createdAt: "2026-04-25T18:01:00.000Z",
+        receiptAt: "2026-04-25T18:01:00.000Z",
+      },
+    ),
+    /Invalid releaseId "\.\.\/\.\.\/outside": path separators are not allowed\./,
+  );
+  assert.equal(await pathExists(outsidePath), false);
+
+  await assert.rejects(
+    persistWave1Release(
+      createManifest({
+        appName,
+        artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:1212121212121212121212121212121212121212121212121212121212121212",
+        rollbackReleaseId: "bootstrap-release",
+        rollbackArtifactRef:
+          "ghcr.io/fawxzzy/lifeline-pilot@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      }),
+      {
+        rootDir: tempRoot,
+        releaseId: "..\\..\\outside",
+        createdAt: "2026-04-25T18:02:00.000Z",
+        receiptAt: "2026-04-25T18:02:00.000Z",
+      },
+    ),
+    /Invalid releaseId "\.\.\\\.\.\\outside": path separators are not allowed\./,
+  );
+  assert.equal(await pathExists(outsidePath), false);
 
   const activationA = await activateWave1Release(
     tempRoot,
@@ -203,6 +287,80 @@ try {
   assert.equal(rollbackReceipt.releaseId, releaseA.releaseId);
   assert.equal(rollbackReceipt.previousReleaseId, releaseB.releaseId);
   assert.equal(rollbackReceipt.health.status, 200);
+
+  const legacyReleaseId = "release-20260425-legacy";
+  const legacyArtifactRef =
+    "ghcr.io/fawxzzy/lifeline-pilot@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+  const legacyMetadata = await writeLegacyReleaseMetadata(
+    tempRoot,
+    createManifest({
+      appName,
+      artifactRef: legacyArtifactRef,
+      rollbackReleaseId: releaseA.releaseId,
+      rollbackArtifactRef: releaseA.releaseMetadata.artifactRef,
+    }),
+    {
+      releaseId: legacyReleaseId,
+      createdAt: "2026-04-25T18:35:00.000Z",
+      dryRun: false,
+    },
+  );
+  const legacyActivation = await activateWave1Release(
+    tempRoot,
+    appName,
+    legacyReleaseId,
+    {
+      receiptAt: "2026-04-25T18:35:00.000Z",
+      checkHealth: async () => ({ ok: true, status: 200 }),
+    },
+  );
+  assert.equal(legacyActivation.ok, true);
+  assert.equal(legacyActivation.current.releaseId, legacyReleaseId);
+  assert.equal(legacyActivation.previous.releaseId, releaseA.releaseId);
+  assert.deepEqual(legacyActivation.receipt.releaseTarget, {
+    kind: "single-host-immutable",
+    releaseId: legacyReleaseId,
+    artifactRef: legacyArtifactRef,
+  });
+
+  const releaseD = await persistWave1Release(
+    createManifest({
+      appName,
+      artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      rollbackReleaseId: legacyReleaseId,
+      rollbackArtifactRef: legacyArtifactRef,
+    }),
+    {
+      rootDir: tempRoot,
+      releaseId: "release-20260425-0004",
+      createdAt: "2026-04-25T18:40:00.000Z",
+      receiptAt: "2026-04-25T18:40:00.000Z",
+    },
+  );
+  const activationD = await activateWave1Release(
+    tempRoot,
+    appName,
+    releaseD.releaseId,
+    {
+      receiptAt: "2026-04-25T18:45:00.000Z",
+      checkHealth: async () => ({ ok: true, status: 200 }),
+    },
+  );
+  assert.equal(activationD.ok, true);
+  assert.equal(activationD.previous.releaseId, legacyReleaseId);
+
+  const legacyRollback = await rollbackWave1Release(tempRoot, appName, {
+    receiptAt: "2026-04-25T18:50:00.000Z",
+    checkHealth: async () => ({ ok: true, status: 200 }),
+  });
+  assert.equal(legacyRollback.ok, true);
+  assert.equal(legacyRollback.current.releaseId, legacyReleaseId);
+  assert.equal(legacyRollback.previous.releaseId, releaseD.releaseId);
+  assert.deepEqual(legacyRollback.receipt.releaseTarget, {
+    kind: "single-host-immutable",
+    releaseId: legacyMetadata.releaseId,
+    artifactRef: legacyMetadata.artifactRef,
+  });
 
   console.log("Wave 1 release mechanics deterministic verification passed.");
 } finally {

--- a/scripts/test-wave1-release-mechanics-deterministic.mjs
+++ b/scripts/test-wave1-release-mechanics-deterministic.mjs
@@ -1,0 +1,210 @@
+import { strict as assert } from "node:assert";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  activateWave1Release,
+  persistWave1Release,
+  readWave1ReleaseState,
+  rollbackWave1Release,
+} from "../control-plane/wave1-release-engine.mjs";
+
+function createManifest({
+  appName,
+  artifactRef,
+  rollbackReleaseId,
+  rollbackArtifactRef,
+}) {
+  return {
+    contractVersion: "atlas.lifeline.deploy-contract.v1",
+    appName,
+    artifactRef,
+    route: {
+      domain: `${appName}.lifeline.internal`,
+      path: "/",
+    },
+    envRefs: [],
+    healthcheckPath: "/healthz",
+    migrationHooks: {
+      preDeploy: ["pnpm verify"],
+      postDeploy: ["pnpm smoke:release"],
+      rollback: ["pnpm rollback:release"],
+    },
+    rollbackTarget: {
+      releaseId: rollbackReleaseId,
+      artifactRef: rollbackArtifactRef,
+      strategy: "restore",
+    },
+  };
+}
+
+async function readJson(rootDir, relativePath) {
+  return JSON.parse(await readFile(path.join(rootDir, relativePath), "utf8"));
+}
+
+const tempRoot = await mkdtemp(
+  path.join(os.tmpdir(), "lifeline-release-mechanics-"),
+);
+
+try {
+  const appName = "lifeline-pilot";
+
+  const releaseA = await persistWave1Release(
+    createManifest({
+      appName,
+      artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      rollbackReleaseId: "bootstrap-release",
+      rollbackArtifactRef:
+        "ghcr.io/fawxzzy/lifeline-pilot@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    }),
+    {
+      rootDir: tempRoot,
+      releaseId: "release-20260425-0001",
+      createdAt: "2026-04-25T18:00:00.000Z",
+      receiptAt: "2026-04-25T18:00:00.000Z",
+    },
+  );
+  assert.equal(releaseA.validation.status, "passed");
+  assert.equal(releaseA.receipt.action, "planned");
+  assert.equal(releaseA.receipt.releaseId, "release-20260425-0001");
+  assert.equal(
+    releaseA.receipt.releaseMetadataPath,
+    ".lifeline/releases/lifeline-pilot/release-20260425-0001/metadata.json",
+  );
+  assert.equal(
+    releaseA.receipt.releaseDirectory,
+    ".lifeline/releases/lifeline-pilot/release-20260425-0001",
+  );
+
+  const activationA = await activateWave1Release(
+    tempRoot,
+    appName,
+    releaseA.releaseId,
+    {
+      receiptAt: "2026-04-25T18:05:00.000Z",
+      checkHealth: async () => ({ ok: true, status: 200 }),
+    },
+  );
+  assert.equal(activationA.ok, true);
+  assert.equal(activationA.current.releaseId, releaseA.releaseId);
+  assert.equal(activationA.previous, undefined);
+
+  const releaseB = await persistWave1Release(
+    createManifest({
+      appName,
+      artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      rollbackReleaseId: releaseA.releaseId,
+      rollbackArtifactRef: releaseA.releaseMetadata.artifactRef,
+    }),
+    {
+      rootDir: tempRoot,
+      releaseId: "release-20260425-0002",
+      createdAt: "2026-04-25T18:10:00.000Z",
+      receiptAt: "2026-04-25T18:10:00.000Z",
+    },
+  );
+  const activationB = await activateWave1Release(
+    tempRoot,
+    appName,
+    releaseB.releaseId,
+    {
+      receiptAt: "2026-04-25T18:15:00.000Z",
+      checkHealth: async () => ({ ok: true, status: 200 }),
+    },
+  );
+  assert.equal(activationB.ok, true);
+  assert.equal(activationB.current.releaseId, releaseB.releaseId);
+  assert.equal(activationB.previous.releaseId, releaseA.releaseId);
+  assert.equal(
+    activationB.receipt.lineage.promotedFromReleaseId,
+    releaseA.releaseId,
+  );
+  assert.equal(
+    activationB.receipt.lineage.promotedToReleaseId,
+    releaseB.releaseId,
+  );
+  assert.equal(activationB.receipt.health.status, 200);
+
+  const stateAfterSuccess = await readWave1ReleaseState(tempRoot, appName);
+  assert.equal(stateAfterSuccess.current.releaseId, releaseB.releaseId);
+  assert.equal(stateAfterSuccess.previous.releaseId, releaseA.releaseId);
+
+  const releaseC = await persistWave1Release(
+    createManifest({
+      appName,
+      artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      rollbackReleaseId: releaseB.releaseId,
+      rollbackArtifactRef: releaseB.releaseMetadata.artifactRef,
+    }),
+    {
+      rootDir: tempRoot,
+      releaseId: "release-20260425-0003",
+      createdAt: "2026-04-25T18:20:00.000Z",
+      receiptAt: "2026-04-25T18:20:00.000Z",
+    },
+  );
+  const failedActivation = await activateWave1Release(
+    tempRoot,
+    appName,
+    releaseC.releaseId,
+    {
+      receiptAt: "2026-04-25T18:25:00.000Z",
+      checkHealth: async () => ({
+        ok: false,
+        status: 503,
+        error: "health gate rejected candidate",
+      }),
+    },
+  );
+  assert.equal(failedActivation.ok, false);
+  assert.equal(failedActivation.current.releaseId, releaseB.releaseId);
+  assert.equal(failedActivation.previous.releaseId, releaseA.releaseId);
+  assert.equal(failedActivation.receipt.status, "failed");
+  assert.equal(
+    failedActivation.receipt.preservedCurrentReleaseId,
+    releaseB.releaseId,
+  );
+
+  const stateAfterFailedActivation = await readWave1ReleaseState(tempRoot, appName);
+  assert.equal(stateAfterFailedActivation.current.releaseId, releaseB.releaseId);
+  assert.equal(stateAfterFailedActivation.previous.releaseId, releaseA.releaseId);
+
+  const rollbackResult = await rollbackWave1Release(tempRoot, appName, {
+    receiptAt: "2026-04-25T18:30:00.000Z",
+    checkHealth: async () => ({ ok: true, status: 200 }),
+  });
+  assert.equal(rollbackResult.ok, true);
+  assert.equal(rollbackResult.current.releaseId, releaseA.releaseId);
+  assert.equal(rollbackResult.previous.releaseId, releaseB.releaseId);
+  assert.equal(rollbackResult.receipt.action, "rollback");
+  assert.equal(rollbackResult.receipt.status, "succeeded");
+  assert.equal(rollbackResult.receipt.previousReleaseId, releaseB.releaseId);
+
+  const finalState = await readWave1ReleaseState(tempRoot, appName);
+  assert.equal(finalState.current.releaseId, releaseA.releaseId);
+  assert.equal(finalState.previous.releaseId, releaseB.releaseId);
+
+  const activationReceipt = await readJson(
+    tempRoot,
+    activationB.receipt.receiptPath,
+  );
+  assert.equal(activationReceipt.releaseId, releaseB.releaseId);
+  assert.equal(activationReceipt.action, "activate");
+  assert.equal(
+    activationReceipt.releaseMetadataPath,
+    ".lifeline/releases/lifeline-pilot/release-20260425-0002/metadata.json",
+  );
+
+  const rollbackReceipt = await readJson(
+    tempRoot,
+    rollbackResult.receipt.receiptPath,
+  );
+  assert.equal(rollbackReceipt.releaseId, releaseA.releaseId);
+  assert.equal(rollbackReceipt.previousReleaseId, releaseB.releaseId);
+  assert.equal(rollbackReceipt.health.status, 200);
+
+  console.log("Wave 1 release mechanics deterministic verification passed.");
+} finally {
+  await rm(tempRoot, { recursive: true, force: true });
+}

--- a/tests/contracts/test-wave1-deploy-contract-deterministic.mjs
+++ b/tests/contracts/test-wave1-deploy-contract-deterministic.mjs
@@ -4,7 +4,10 @@ import { fileURLToPath } from "node:url";
 import path from "node:path";
 
 import {
+  buildWave1ReleaseMetadata,
+  buildWave1ReleasePlan,
   buildWave1DryRunPlan,
+  deriveWave1ReleaseId,
   parseWave1ReleaseMetadata,
   serializeWave1ReleaseMetadata,
   validateWave1DeployManifest,
@@ -47,6 +50,7 @@ const validation = validateWave1DeployManifest(sampleManifest);
 assert.equal(validation.issues.length, 0, `unexpected deploy issues: ${JSON.stringify(validation.issues, null, 2)}`);
 assert.equal(validation.manifest?.contractVersion, WAVE1_DEPLOY_CONTRACT_VERSION);
 assert.equal(validation.manifest?.artifactRef, sampleManifest.imageRef);
+assert.equal(validation.manifest?.sourceAdapter?.kind, "imageRef");
 assert.equal(JSON.stringify(sampleManifest), originalManifestSnapshot, "dry-run validation must not mutate the input manifest");
 
 const dryRunPlan = buildWave1DryRunPlan(sampleManifest, {
@@ -62,18 +66,103 @@ assert.deepEqual(
     "validate-manifest",
     "canonicalize-artifact-ref",
     "prepare-release-metadata",
+    "derive-release-target",
     "preserve-rollback-target",
   ],
 );
 assert.equal(dryRunPlan.releaseMetadata?.contractVersion, WAVE1_RELEASE_METADATA_VERSION);
 assert.equal(dryRunPlan.releaseMetadata?.artifactRef, sampleManifest.imageRef);
 assert.equal(dryRunPlan.releaseMetadata?.dryRun, true);
+assert.equal(dryRunPlan.releaseMetadata?.sourceAdapter?.kind, "imageRef");
+assert.deepEqual(dryRunPlan.releaseMetadata?.releaseTarget, {
+  kind: "single-host-immutable",
+  releaseId: "release-20260421-0002",
+  artifactRef: sampleManifest.imageRef,
+});
 
 const roundTripped = parseWave1ReleaseMetadata(
   serializeWave1ReleaseMetadata(dryRunPlan.releaseMetadata),
 );
 assert.equal(roundTripped.issues.length, 0, `unexpected release metadata issues: ${JSON.stringify(roundTripped.issues, null, 2)}`);
 assert.deepEqual(roundTripped.metadata, dryRunPlan.releaseMetadata);
+
+const deterministicReleaseId = deriveWave1ReleaseId(sampleManifest);
+assert.equal(
+  deterministicReleaseId,
+  deriveWave1ReleaseId(sampleManifest),
+  "release ids must be deterministic for identical normalized manifests",
+);
+assert.ok(
+  deterministicReleaseId?.startsWith("release-lifeline-pilot-"),
+  `expected deterministic release id prefix, got ${deterministicReleaseId}`,
+);
+
+const branchShapedManifest = {
+  contractVersion: WAVE1_DEPLOY_CONTRACT_VERSION,
+  appName: "trove",
+  repo: "https://github.com/fawxzzy/fawxzzy-trove.git",
+  branch: "codex/trove-one-page-cleanup",
+  route: {
+    domain: "trove.fawxzzy.com",
+    path: "/",
+  },
+  envRefs: [],
+  healthcheckPath: "/healthz.json",
+  migrationHooks: {
+    preDeploy: ["npm run verify"],
+    postDeploy: ["npm run smoke:lifeline"],
+    rollback: ["lifeline down trove"],
+  },
+  rollbackTarget: {
+    releaseId: "pre-w4-a9c347b",
+    artifactRef:
+      "git+https://github.com/fawxzzy/fawxzzy-trove.git#a9c347b5bc510503691478aa680e34cfa9ab81a7",
+    strategy: "restore",
+  },
+};
+const branchValidation = validateWave1DeployManifest(branchShapedManifest);
+assert.equal(branchValidation.issues.length, 0, `unexpected branch-shaped issues: ${JSON.stringify(branchValidation.issues, null, 2)}`);
+assert.equal(
+  branchValidation.manifest?.artifactRef,
+  "git+https://github.com/fawxzzy/fawxzzy-trove.git#codex/trove-one-page-cleanup",
+);
+assert.deepEqual(branchValidation.manifest?.sourceAdapter, {
+  kind: "branch",
+  repo: "https://github.com/fawxzzy/fawxzzy-trove.git",
+  branch: "codex/trove-one-page-cleanup",
+  canonicalArtifactRef:
+    "git+https://github.com/fawxzzy/fawxzzy-trove.git#codex/trove-one-page-cleanup",
+});
+
+const branchReleaseMetadata = buildWave1ReleaseMetadata(branchShapedManifest, {
+  releaseId: "release-trove-branch-adapter",
+  createdAt: "2026-04-25T18:00:00.000Z",
+});
+assert.equal(branchReleaseMetadata.issues.length, 0);
+assert.equal(
+  branchReleaseMetadata.metadata?.releaseTarget.releaseId,
+  "release-trove-branch-adapter",
+);
+assert.equal(branchReleaseMetadata.metadata?.sourceAdapter?.kind, "branch");
+
+const releasePlan = buildWave1ReleasePlan(branchShapedManifest, {
+  createdAt: "2026-04-25T18:00:00.000Z",
+});
+assert.equal(releasePlan.validation.status, "passed");
+assert.deepEqual(
+  releasePlan.steps.map((step) => step.step),
+  [
+    "validate-manifest",
+    "canonicalize-artifact-ref",
+    "derive-release-id",
+    "derive-release-target",
+    "preserve-rollback-target",
+  ],
+);
+assert.equal(
+  releasePlan.releaseMetadata?.releaseTarget.artifactRef,
+  branchValidation.manifest?.artifactRef,
+);
 
 const invalidManifest = validateWave1DeployManifest({
   ...sampleManifest,
@@ -117,6 +206,9 @@ assert.equal(
 assert.ok(
   docs.includes("artifactRef") &&
     docs.includes("imageRef") &&
+    docs.includes("repo") &&
+    docs.includes("branch") &&
+    docs.includes("releaseTarget") &&
     docs.includes("rollbackTarget.strategy"),
   "docs/contracts/wave1-deploy-contract.md should describe the canonical deploy and metadata fields",
 );

--- a/tests/contracts/test-wave1-deploy-contract-deterministic.mjs
+++ b/tests/contracts/test-wave1-deploy-contract-deterministic.mjs
@@ -86,6 +86,25 @@ const roundTripped = parseWave1ReleaseMetadata(
 assert.equal(roundTripped.issues.length, 0, `unexpected release metadata issues: ${JSON.stringify(roundTripped.issues, null, 2)}`);
 assert.deepEqual(roundTripped.metadata, dryRunPlan.releaseMetadata);
 
+const legacyV1Metadata = {
+  ...dryRunPlan.releaseMetadata,
+};
+delete legacyV1Metadata.releaseTarget;
+
+const roundTrippedLegacy = parseWave1ReleaseMetadata(
+  JSON.stringify(legacyV1Metadata, null, 2),
+);
+assert.equal(
+  roundTrippedLegacy.issues.length,
+  0,
+  `unexpected legacy release metadata issues: ${JSON.stringify(roundTrippedLegacy.issues, null, 2)}`,
+);
+assert.deepEqual(roundTrippedLegacy.metadata?.releaseTarget, {
+  kind: "single-host-immutable",
+  releaseId: "release-20260421-0002",
+  artifactRef: sampleManifest.imageRef,
+});
+
 const deterministicReleaseId = deriveWave1ReleaseId(sampleManifest);
 assert.equal(
   deterministicReleaseId,


### PR DESCRIPTION
## Summary

- harden and extend the existing Wave 1 deploy contract already on main
- preserve compatibility for:
  - branch-shaped repo/branch inputs
  - imageRef -> artifactRef canonicalization
- derive deterministic release ids, releaseTarget, and sourceAdapter metadata
- add an immutable single-host release engine with:
  - release directories
  - current/previous state
  - health-gated activation
  - rollback to previous known-good release
  - release receipts tied to concrete release ids
- expand deterministic contract and release-mechanics coverage
- wire the new release-mechanics tests into `pnpm run verify`

## Verification

- `pnpm run verify`

## Scope note

- this PR does not add domains, preview URLs, TLS, or hosted control-plane behavior
- this PR preserves current compatibility adapters so Trove can move in the next lane