### PR TITLE
Lifeline: bind operator evidence to Wave 1 release state

### DIFF
--- a/docs/ops/lifeline-operator-surface.md
+++ b/docs/ops/lifeline-operator-surface.md
@@ -30,6 +30,7 @@ Why this order matters:
 - Managed app output is appended under `.lifeline/logs/<app-name>.log`.
 - Each `lifeline up` cycle starts with a header line in the log file.
 - `lifeline logs <app-name> [line-count]` tails the log file, with `100` lines as the default.
+- When Wave 1 release state exists, `lifeline logs` prints the current and previous release ids before the tailed log lines so incident notes stay bound to a concrete release lineage.
 - Log output is line-oriented and stable enough for operators to grep, tail, and attach to incident notes.
 
 Useful signals:
@@ -43,6 +44,7 @@ Useful signals:
 - `lifeline status <app-name>` is the primary health visibility command.
 - Healthy state requires the supervisor, the managed child process, port ownership, and a successful health check.
 - The status output always reports the local healthcheck URL, last known status, log path, manifest path, restart policy, and crash-loop state.
+- When Wave 1 release state exists, `lifeline status` also reports the current release id, previous release id, current artifact ref, rollback target, and recent release receipts.
 - `lifeline status <app-name> --proof-text` gives a compact operator brief.
 - `lifeline status <app-name> --proof-gate` makes the proof brief fail closed.
 
@@ -50,6 +52,8 @@ Useful signals:
 
 - `App <name> is running.` means the pilot can proceed.
 - `- health: ok (200)` means the managed app is answering the healthcheck.
+- `- currentReleaseId:` and `- previousReleaseId:` identify the live and rollback-adjacent release lineage.
+- `- rollbackTarget.releaseId:` and `- receipt:` lines show the concrete rollback target and recent release receipts.
 - `blockedReason` or `- health: managed app process not running` means cutover should stop.
 
 ## Receipt contract

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "verify": "pnpm typecheck && pnpm build && pnpm test:wave1-deploy-contract && pnpm test:wave1-release-mechanics && pnpm test:privileged-execution-bridge && pnpm test:privileged-execution-repair && pnpm test:ui-proof-receipt",
+    "verify": "pnpm typecheck && pnpm build && pnpm test:wave1-deploy-contract && pnpm test:wave1-release-mechanics && pnpm test:wave1-operator-evidence && pnpm test:privileged-execution-bridge && pnpm test:privileged-execution-repair && pnpm test:ui-proof-receipt",
     "check": "biome check .",
     "format": "biome format --write .",
     "validate:fitness": "node dist/cli.js validate examples/fitness-app.lifeline.yml",
@@ -63,6 +63,7 @@
     "smoke:runtime:restore-missing-env-file": "node scripts/smoke-runtime-restore-missing-env-file.mjs",
     "test:wave1-deploy-contract": "node tests/contracts/test-wave1-deploy-contract-deterministic.mjs",
     "test:wave1-release-mechanics": "node scripts/test-wave1-release-mechanics-deterministic.mjs",
+    "test:wave1-operator-evidence": "node scripts/test-wave1-operator-evidence-deterministic.mjs",
     "test:startup-deterministic": "node scripts/test-wave2-startup-deterministic.mjs",
     "test:startup-roundtrip": "node scripts/test-startup-roundtrip-windows-deterministic.mjs",
     "test:privileged-execution-bridge": "node scripts/test-privileged-execution-worker-bridge-deterministic.mjs",

--- a/scripts/test-wave1-operator-evidence-deterministic.mjs
+++ b/scripts/test-wave1-operator-evidence-deterministic.mjs
@@ -1,0 +1,263 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { copyFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { persistWave1Release, activateWave1Release } from "../control-plane/wave1-release-engine.mjs";
+import { ensureBuilt } from "./lib/ensure-built.mjs";
+
+await ensureBuilt();
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const fixtureSourceDir = path.join(repoRoot, "fixtures", "runtime-smoke-app");
+const cliPath = path.join(repoRoot, "dist", "cli.js");
+const appName = "runtime-smoke-app";
+
+function runCli(args, { cwd, allowFailure = false } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [cliPath, ...args], {
+      cwd,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code !== 0 && !allowFailure) {
+        reject(
+          new Error(
+            `Command failed: node ${cliPath} ${args.join(" ")}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+          ),
+        );
+        return;
+      }
+
+      resolve({ code: code ?? 1, stdout, stderr });
+    });
+  });
+}
+
+function assertIncludes(output, fragment, label) {
+  assert(
+    output.includes(fragment),
+    `${label}; expected to find ${JSON.stringify(fragment)} in output:\n${output}`,
+  );
+}
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("Expected a numeric local port.")));
+        return;
+      }
+
+      const port = address.port;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve(port);
+      });
+    });
+  });
+}
+
+async function createDisposableFixtureRoot(port) {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lifeline-release-evidence-fixture-"));
+  const manifestPath = path.join(tempRoot, `${appName}.lifeline.yml`);
+
+  await copyFile(path.join(fixtureSourceDir, "server.js"), path.join(tempRoot, "server.js"));
+
+  const envSource = await readFile(path.join(fixtureSourceDir, ".env.runtime"), "utf8");
+  const envContent = envSource.replace(/^PORT=.*$/m, `PORT=${port}`);
+  await writeFile(path.join(tempRoot, ".env.runtime"), envContent, "utf8");
+
+  const manifestSource = await readFile(
+    path.join(fixtureSourceDir, `${appName}.lifeline.yml`),
+    "utf8",
+  );
+  const manifestContent = manifestSource.replace(/^port:\s*\d+$/m, `port: ${port}`);
+  await writeFile(manifestPath, manifestContent, "utf8");
+
+  return { tempRoot, manifestPath };
+}
+
+function createReleaseManifest({ artifactRef, rollbackReleaseId, rollbackArtifactRef, port }) {
+  return {
+    contractVersion: "atlas.lifeline.deploy-contract.v1",
+    appName,
+    artifactRef,
+    route: {
+      domain: `${appName}.lifeline.internal`,
+      path: "/",
+    },
+    envRefs: [],
+    healthcheckPath: "/healthz",
+    migrationHooks: {
+      preDeploy: ["pnpm verify"],
+      postDeploy: ["pnpm smoke:release"],
+      rollback: ["pnpm rollback:release"],
+    },
+    rollbackTarget: {
+      releaseId: rollbackReleaseId,
+      artifactRef: rollbackArtifactRef,
+      strategy: "restore",
+      note: `rollback ${appName} on port ${port}`,
+    },
+  };
+}
+
+async function removeTreeWithRetries(targetPath) {
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    try {
+      await rm(targetPath, { recursive: true, force: true });
+      return true;
+    } catch (error) {
+      const isBusy =
+        error instanceof Error &&
+        "code" in error &&
+        (error.code === "EBUSY" || error.code === "ENOTEMPTY");
+      if (!isBusy || attempt === 5) {
+        return false;
+      }
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, 200 * (attempt + 1));
+      });
+    }
+  }
+
+  return false;
+}
+
+const tempWorkspace = await mkdtemp(
+  path.join(os.tmpdir(), "lifeline-release-evidence-workspace-"),
+);
+const port = await getFreePort();
+const { tempRoot: fixtureRoot, manifestPath } = await createDisposableFixtureRoot(port);
+
+let cleanupNeeded = true;
+
+try {
+  const upResult = await runCli(["up", manifestPath], {
+    cwd: tempWorkspace,
+    allowFailure: true,
+  });
+  assert.equal(upResult.code, 0, `up: expected exit 0, got ${upResult.code}\n${upResult.stdout}\n${upResult.stderr}`);
+
+  const releaseA = await persistWave1Release(
+    createReleaseManifest({
+      artifactRef: "docker://runtime-smoke-app:release-a",
+      rollbackReleaseId: "bootstrap-release",
+      rollbackArtifactRef: "docker://runtime-smoke-app:bootstrap",
+      port,
+    }),
+    {
+      rootDir: tempWorkspace,
+      releaseId: "release-runtime-smoke-app-a",
+      createdAt: "2026-04-26T00:00:00.000Z",
+      receiptAt: "2026-04-26T00:00:00.000Z",
+    },
+  );
+  await activateWave1Release(tempWorkspace, appName, releaseA.releaseId, {
+    receiptAt: "2026-04-26T00:01:00.000Z",
+    checkHealth: async () => ({ ok: true, status: 200 }),
+  });
+
+  const releaseB = await persistWave1Release(
+    createReleaseManifest({
+      artifactRef: "docker://runtime-smoke-app:release-b",
+      rollbackReleaseId: releaseA.releaseId,
+      rollbackArtifactRef: releaseA.releaseMetadata.artifactRef,
+      port,
+    }),
+    {
+      rootDir: tempWorkspace,
+      releaseId: "release-runtime-smoke-app-b",
+      createdAt: "2026-04-26T00:02:00.000Z",
+      receiptAt: "2026-04-26T00:02:00.000Z",
+    },
+  );
+  await activateWave1Release(tempWorkspace, appName, releaseB.releaseId, {
+    receiptAt: "2026-04-26T00:03:00.000Z",
+    checkHealth: async () => ({ ok: true, status: 200 }),
+  });
+
+  const statusResult = await runCli(["status", appName], {
+    cwd: tempWorkspace,
+    allowFailure: true,
+  });
+  assert.equal(
+    statusResult.code,
+    0,
+    `status: expected exit 0, got ${statusResult.code}\n${statusResult.stdout}\n${statusResult.stderr}`,
+  );
+  assertIncludes(statusResult.stdout, "- currentReleaseId: release-runtime-smoke-app-b", "status: missing current release id");
+  assertIncludes(statusResult.stdout, "- previousReleaseId: release-runtime-smoke-app-a", "status: missing previous release id");
+  assertIncludes(statusResult.stdout, "- currentArtifactRef: docker://runtime-smoke-app:release-b", "status: missing current artifact ref");
+  assertIncludes(statusResult.stdout, "- rollbackTarget.releaseId: release-runtime-smoke-app-a", "status: missing rollback release id");
+  assertIncludes(statusResult.stdout, "- rollbackTarget.artifactRef: docker://runtime-smoke-app:release-a", "status: missing rollback artifact ref");
+  assertIncludes(statusResult.stdout, "- rollbackTarget.strategy: restore", "status: missing rollback strategy");
+  assertIncludes(statusResult.stdout, "- receiptsDir: .lifeline/releases/runtime-smoke-app/receipts", "status: missing receipts dir");
+  assertIncludes(statusResult.stdout, "- receipt: activate succeeded release-runtime-smoke-app-b", "status: missing receipt summary");
+
+  const proofResult = await runCli(["status", appName, "--proof-text"], {
+    cwd: tempWorkspace,
+    allowFailure: true,
+  });
+  assert.equal(
+    proofResult.code,
+    0,
+    `proof-text: expected exit 0, got ${proofResult.code}\n${proofResult.stdout}\n${proofResult.stderr}`,
+  );
+  assertIncludes(proofResult.stdout, "- currentReleaseId: release-runtime-smoke-app-b", "proof-text: missing current release id");
+  assertIncludes(proofResult.stdout, "- previousReleaseId: release-runtime-smoke-app-a", "proof-text: missing previous release id");
+  assertIncludes(proofResult.stdout, "- rollbackTarget: release-runtime-smoke-app-a (restore)", "proof-text: missing rollback target");
+
+  const logsResult = await runCli(["logs", appName, "20"], {
+    cwd: tempWorkspace,
+    allowFailure: true,
+  });
+  assert.equal(
+    logsResult.code,
+    0,
+    `logs: expected exit 0, got ${logsResult.code}\n${logsResult.stdout}\n${logsResult.stderr}`,
+  );
+  assertIncludes(logsResult.stdout, `=== lifeline logs ${appName} ===`, "logs: missing evidence header");
+  assertIncludes(logsResult.stdout, "- currentReleaseId: release-runtime-smoke-app-b", "logs: missing current release id");
+  assertIncludes(logsResult.stdout, "- previousReleaseId: release-runtime-smoke-app-a", "logs: missing previous release id");
+  assertIncludes(logsResult.stdout, "=== lifeline up ", "logs: missing startup header");
+  assertIncludes(logsResult.stdout, `runtime-smoke-app listening on ${port}`, "logs: missing app startup line");
+
+  cleanupNeeded = false;
+  console.log("Wave 1 operator evidence deterministic verification passed.");
+} finally {
+  if (cleanupNeeded) {
+    await runCli(["down", appName], { cwd: tempWorkspace, allowFailure: true }).catch(() => undefined);
+  }
+
+  await runCli(["down", appName], { cwd: tempWorkspace, allowFailure: true }).catch(() => undefined);
+  await removeTreeWithRetries(tempWorkspace);
+  await removeTreeWithRetries(fixtureRoot);
+}

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -1,4 +1,5 @@
 import { tailLogFile } from "../core/log-store.js";
+import { readReleaseOperatorEvidence } from "../core/release-state.js";
 import { getAppState } from "../core/state-store.js";
 
 export async function runLogsCommand(
@@ -11,10 +12,23 @@ export async function runLogsCommand(
     return 1;
   }
 
+  const releaseEvidence = await readReleaseOperatorEvidence(appName);
   const lines = await tailLogFile(state.logPath, lineCount);
   if (lines.length === 0) {
     console.log(`No logs found for app ${appName} at ${state.logPath}.`);
     return 0;
+  }
+
+  if (releaseEvidence) {
+    console.log(`=== lifeline logs ${appName} ===`);
+    console.log(`- log: ${state.logPath}`);
+    if (releaseEvidence.current) {
+      console.log(`- currentReleaseId: ${releaseEvidence.current.releaseId}`);
+    }
+    if (releaseEvidence.previous) {
+      console.log(`- previousReleaseId: ${releaseEvidence.previous.releaseId}`);
+    }
+    console.log("");
   }
 
   console.log(lines.join("\n"));

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -2,6 +2,7 @@ import {
   findListeningPortOwnerPid,
   isProcessAlive,
 } from "../core/process-manager.js";
+import { readReleaseOperatorEvidence } from "../core/release-state.js";
 import { checkHealth } from "../core/healthcheck.js";
 import { getAppState, upsertAppState } from "../core/state-store.js";
 
@@ -26,6 +27,7 @@ type RuntimeSnapshot = {
     error?: string;
     status?: number;
   };
+  release?: Awaited<ReturnType<typeof readReleaseOperatorEvidence>>;
 };
 
 type ProofState = "ready" | "blocked" | "conflicted" | "not-ready";
@@ -106,8 +108,62 @@ function serializeProofPayload(snapshot: RuntimeSnapshot): {
       error?: string;
     };
   };
+  release?: {
+    current_release_id?: string;
+    current_artifact_ref?: string;
+    previous_release_id?: string;
+    rollback_target?: {
+      release_id: string;
+      artifact_ref: string;
+      strategy: string;
+      note?: string;
+    };
+    receipts_dir: string;
+    latest_receipts: Array<{
+      receipt_id: string;
+      action: string;
+      status: string;
+      release_id: string;
+      path: string;
+    }>;
+  };
 } {
   const proof = deriveProof(snapshot);
+  const release = snapshot.release
+    ? {
+        ...(snapshot.release.current
+          ? {
+              current_release_id: snapshot.release.current.releaseId,
+              ...(snapshot.release.current.artifactRef
+                ? { current_artifact_ref: snapshot.release.current.artifactRef }
+                : {}),
+            }
+          : {}),
+        ...(snapshot.release.previous
+          ? { previous_release_id: snapshot.release.previous.releaseId }
+          : {}),
+        ...(snapshot.release.rollbackTarget
+          ? {
+              rollback_target: {
+                release_id: snapshot.release.rollbackTarget.releaseId,
+                artifact_ref: snapshot.release.rollbackTarget.artifactRef,
+                strategy: snapshot.release.rollbackTarget.strategy,
+                ...(snapshot.release.rollbackTarget.note
+                  ? { note: snapshot.release.rollbackTarget.note }
+                  : {}),
+              },
+            }
+          : {}),
+        receipts_dir: snapshot.release.receiptsDir,
+        latest_receipts: snapshot.release.latestReceipts.map((receipt) => ({
+          receipt_id: receipt.receiptId,
+          action: receipt.action,
+          status: receipt.status,
+          release_id: receipt.releaseId,
+          path: receipt.path,
+        })),
+      }
+    : undefined;
 
   return {
     mode: "proof",
@@ -128,6 +184,7 @@ function serializeProofPayload(snapshot: RuntimeSnapshot): {
         ...(snapshot.health.error ? { error: snapshot.health.error } : {}),
       },
     },
+    ...(release ? { release } : {}),
   };
 }
 
@@ -157,6 +214,17 @@ function printProofText(payload: ReturnType<typeof serializeProofPayload>): void
   console.log(
     `- health: ${payload.runtime.health.ok ? `ok (${payload.runtime.health.status ?? 200})` : (payload.runtime.health.error ?? "failed")}`,
   );
+  if (payload.release?.current_release_id) {
+    console.log(`- currentReleaseId: ${payload.release.current_release_id}`);
+  }
+  if (payload.release?.previous_release_id) {
+    console.log(`- previousReleaseId: ${payload.release.previous_release_id}`);
+  }
+  if (payload.release?.rollback_target) {
+    console.log(
+      `- rollbackTarget: ${payload.release.rollback_target.release_id} (${payload.release.rollback_target.strategy})`,
+    );
+  }
 }
 
 function resolveProofExitCode(
@@ -235,6 +303,7 @@ export async function runStatusCommand(
 
   state.portOwnerPid = portOwnerPid;
   await upsertAppState(state);
+  const releaseEvidence = await readReleaseOperatorEvidence(appName);
 
   const runtimeSnapshot: RuntimeSnapshot = {
     appName,
@@ -246,6 +315,7 @@ export async function runStatusCommand(
     inferredManagedPid,
     portOwnerPid,
     health,
+    release: releaseEvidence,
   };
 
   if (options.mode === "proof-json" || options.mode === "proof-text") {
@@ -282,6 +352,40 @@ export async function runStatusCommand(
   console.log(`- manifest: ${state.manifestPath}`);
   if (state.playbookPath) {
     console.log(`- playbook: ${state.playbookPath}`);
+  }
+  if (releaseEvidence?.current) {
+    console.log(`- currentReleaseId: ${releaseEvidence.current.releaseId}`);
+    if (releaseEvidence.current.artifactRef) {
+      console.log(`- currentArtifactRef: ${releaseEvidence.current.artifactRef}`);
+    }
+    if (releaseEvidence.current.metadataPath) {
+      console.log(`- releaseMetadata: ${releaseEvidence.current.metadataPath}`);
+    }
+  }
+  if (releaseEvidence?.previous) {
+    console.log(`- previousReleaseId: ${releaseEvidence.previous.releaseId}`);
+    if (releaseEvidence.previous.artifactRef) {
+      console.log(`- previousArtifactRef: ${releaseEvidence.previous.artifactRef}`);
+    }
+  }
+  if (releaseEvidence?.rollbackTarget) {
+    console.log(
+      `- rollbackTarget.releaseId: ${releaseEvidence.rollbackTarget.releaseId}`,
+    );
+    console.log(
+      `- rollbackTarget.artifactRef: ${releaseEvidence.rollbackTarget.artifactRef}`,
+    );
+    console.log(
+      `- rollbackTarget.strategy: ${releaseEvidence.rollbackTarget.strategy}`,
+    );
+  }
+  if (releaseEvidence?.latestReceipts.length) {
+    console.log(`- receiptsDir: ${releaseEvidence.receiptsDir}`);
+    for (const receipt of releaseEvidence.latestReceipts) {
+      console.log(
+        `- receipt: ${receipt.action} ${receipt.status} ${receipt.releaseId} (${receipt.path})`,
+      );
+    }
   }
   console.log(`- restartPolicy: ${state.restartPolicy}`);
   console.log(`- restartCount: ${state.restartCount}`);

--- a/src/core/release-state.ts
+++ b/src/core/release-state.ts
@@ -1,0 +1,237 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+export interface ReleasePointer {
+  releaseId: string;
+  updatedAt: string;
+  reason?: string;
+}
+
+export interface ReleaseRecord {
+  releaseId: string;
+  updatedAt: string;
+  reason?: string;
+  artifactRef?: string;
+  metadataPath?: string;
+}
+
+export interface ReleaseRollbackTarget {
+  releaseId: string;
+  artifactRef: string;
+  strategy: string;
+  note?: string;
+}
+
+export interface ReleaseReceiptSummary {
+  receiptId: string;
+  action: string;
+  status: string;
+  releaseId: string;
+  createdAt?: string;
+  path: string;
+}
+
+export interface ReleaseOperatorEvidence {
+  current?: ReleaseRecord;
+  previous?: ReleaseRecord;
+  rollbackTarget?: ReleaseRollbackTarget;
+  receiptsDir: string;
+  latestReceipts: ReleaseReceiptSummary[];
+}
+
+interface ReleaseMetadataLike {
+  artifactRef?: string;
+  rollbackTarget?: ReleaseRollbackTarget;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function normalizeRelativePath(rootDir: string, filePath: string): string {
+  return path.relative(rootDir, filePath).replace(/\\/g, "/");
+}
+
+async function readJsonIfPresent(filePath: string): Promise<unknown | undefined> {
+  const raw = await readFile(filePath, "utf8").catch(() => "");
+  if (!raw) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+async function readReleasePointer(filePath: string): Promise<ReleasePointer | undefined> {
+  const parsed = await readJsonIfPresent(filePath);
+  if (!isRecord(parsed)) {
+    return undefined;
+  }
+
+  if (!isNonEmptyString(parsed.releaseId) || !isNonEmptyString(parsed.updatedAt)) {
+    return undefined;
+  }
+
+  return {
+    releaseId: parsed.releaseId,
+    updatedAt: parsed.updatedAt,
+    ...(isNonEmptyString(parsed.reason) ? { reason: parsed.reason } : {}),
+  };
+}
+
+async function readReleaseMetadata(
+  metadataPath: string,
+): Promise<ReleaseMetadataLike | undefined> {
+  const parsed = await readJsonIfPresent(metadataPath);
+  if (!isRecord(parsed)) {
+    return undefined;
+  }
+
+  const metadata: ReleaseMetadataLike = {};
+  if (isNonEmptyString(parsed.artifactRef)) {
+    metadata.artifactRef = parsed.artifactRef;
+  }
+
+  if (isRecord(parsed.rollbackTarget)) {
+    const rollbackTarget = parsed.rollbackTarget;
+    if (
+      isNonEmptyString(rollbackTarget.releaseId) &&
+      isNonEmptyString(rollbackTarget.artifactRef) &&
+      isNonEmptyString(rollbackTarget.strategy)
+    ) {
+      metadata.rollbackTarget = {
+        releaseId: rollbackTarget.releaseId,
+        artifactRef: rollbackTarget.artifactRef,
+        strategy: rollbackTarget.strategy,
+        ...(isNonEmptyString(rollbackTarget.note)
+          ? { note: rollbackTarget.note }
+          : {}),
+      };
+    }
+  }
+
+  return metadata;
+}
+
+async function readReleaseRecord(
+  rootDir: string,
+  appName: string,
+  pointer: ReleasePointer | undefined,
+): Promise<ReleaseRecord | undefined> {
+  if (!pointer) {
+    return undefined;
+  }
+
+  const metadataPath = path.join(
+    rootDir,
+    ".lifeline",
+    "releases",
+    appName,
+    pointer.releaseId,
+    "metadata.json",
+  );
+  const metadata = await readReleaseMetadata(metadataPath);
+
+  return {
+    releaseId: pointer.releaseId,
+    updatedAt: pointer.updatedAt,
+    ...(pointer.reason ? { reason: pointer.reason } : {}),
+    ...(metadata?.artifactRef ? { artifactRef: metadata.artifactRef } : {}),
+    ...(metadata ? { metadataPath: normalizeRelativePath(rootDir, metadataPath) } : {}),
+  };
+}
+
+async function readLatestReceipts(
+  rootDir: string,
+  receiptsDir: string,
+): Promise<ReleaseReceiptSummary[]> {
+  const entries = (await readdir(receiptsDir).catch(() => [])) as string[];
+  const receipts: Array<ReleaseReceiptSummary & { sortAt: number }> = [];
+
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) {
+      continue;
+    }
+
+    const receiptPath = path.join(receiptsDir, entry);
+    const parsed = await readJsonIfPresent(receiptPath);
+    if (!isRecord(parsed)) {
+      continue;
+    }
+
+    if (
+      !isNonEmptyString(parsed.receiptId) ||
+      !isNonEmptyString(parsed.action) ||
+      !isNonEmptyString(parsed.status) ||
+      !isNonEmptyString(parsed.releaseId)
+    ) {
+      continue;
+    }
+
+    const createdAt =
+      isNonEmptyString(parsed.createdAt) ? parsed.createdAt : undefined;
+    const sortAt = createdAt ? Date.parse(createdAt) : Number.NaN;
+
+    receipts.push({
+      receiptId: parsed.receiptId,
+      action: parsed.action,
+      status: parsed.status,
+      releaseId: parsed.releaseId,
+      ...(createdAt ? { createdAt } : {}),
+      path: normalizeRelativePath(rootDir, receiptPath),
+      sortAt: Number.isNaN(sortAt) ? 0 : sortAt,
+    });
+  }
+
+  return receipts
+    .sort((left, right) => right.sortAt - left.sortAt)
+    .slice(0, 3)
+    .map(({ sortAt: _sortAt, ...receipt }) => receipt);
+}
+
+export async function readReleaseOperatorEvidence(
+  appName: string,
+  rootDir = process.cwd(),
+): Promise<ReleaseOperatorEvidence | undefined> {
+  const resolvedRoot = path.resolve(rootDir);
+  const appReleaseRoot = path.join(resolvedRoot, ".lifeline", "releases", appName);
+  const currentPointerPath = path.join(appReleaseRoot, "current.json");
+  const previousPointerPath = path.join(appReleaseRoot, "previous.json");
+  const receiptsDir = path.join(appReleaseRoot, "receipts");
+
+  const [currentPointer, previousPointer] = await Promise.all([
+    readReleasePointer(currentPointerPath),
+    readReleasePointer(previousPointerPath),
+  ]);
+
+  const [current, previous] = await Promise.all([
+    readReleaseRecord(resolvedRoot, appName, currentPointer),
+    readReleaseRecord(resolvedRoot, appName, previousPointer),
+  ]);
+
+  const currentMetadata = current?.metadataPath
+    ? await readReleaseMetadata(path.join(resolvedRoot, current.metadataPath))
+    : undefined;
+  const latestReceipts = await readLatestReceipts(resolvedRoot, receiptsDir);
+
+  if (!current && !previous && latestReceipts.length === 0) {
+    return undefined;
+  }
+
+  return {
+    ...(current ? { current } : {}),
+    ...(previous ? { previous } : {}),
+    ...(currentMetadata?.rollbackTarget
+      ? { rollbackTarget: currentMetadata.rollbackTarget }
+      : {}),
+    receiptsDir: normalizeRelativePath(resolvedRoot, receiptsDir),
+    latestReceipts,
+  };
+}


### PR DESCRIPTION
## Summary
- bind operator evidence to real Wave 1 release state
- teach `lifeline status` to report:
  - current release id
  - previous release id
  - current artifact ref
  - rollback target
  - recent receipts
- teach `lifeline logs` to print current/previous release context before tailed log lines
- add a release-state helper and deterministic operator-evidence coverage
- include the new operator-evidence test in `pnpm run verify`

## Verification
- pnpm run verify