### PR TITLE
Lifeline: add topology contract intake validator

### DIFF
--- a/docs/contracts/topology-manifest.md
+++ b/docs/contracts/topology-manifest.md
@@ -1,0 +1,49 @@
+# Topology manifest intake contract
+
+Lifeline consumes the ATLAS-owned topology manifest as an intake contract for public app and operator hostname resolution. Lifeline does not become the source of truth for zones, public hostname policy, DNS automation, TLS automation, or reverse-proxy ownership.
+
+## Canonical source
+
+- ATLAS root manifest: `../../docs/LIFELINE_TOPOLOGY_MANIFEST.json`
+- ATLAS source docs:
+  - `../../docs/LIFELINE_HOSTING_TOPOLOGY.md`
+  - `../../docs/LIFELINE_ENV_AND_DOMAIN_CONTRACT.md`
+
+The canonical manifest schema version is `atlas.topology.manifest.v1`.
+
+## Lifeline intake responsibilities
+
+- validate the manifest shape before using it
+- resolve one stable service identity at the `app/environment` layer
+- resolve public hostname intent without embedding placement identity
+- preserve app-specific exceptions such as Lifeline prod using `lifeline.{zone}`
+- treat `dev` as local-only with no public hostname
+
+## Resolution rules
+
+- Stable service key template: `{app}/{environment}`
+- Named environments:
+  - `dev`
+  - `preview`
+  - `prod`
+- Approved ephemeral public environment template: `pr-{number}`
+- Default hostname templates:
+  - prod: `{app}.{zone}`
+  - preview: `preview-{app}.{zone}`
+  - pr preview: `pr-{number}.{app}.{zone}`
+- Lifeline exception:
+  - prod: `lifeline.{zone}`
+  - preview: no public hostname
+  - pr preview: no public hostname
+
+Lifeline resolution must prefer app-specific hostname rules over generic rules and must keep the public unit stable even when no public hostname is emitted.
+
+## Out of scope
+
+This intake contract explicitly excludes:
+
+- hosted control plane behavior
+- reverse proxy ownership
+- domain automation
+- TLS automation
+- multi-node orchestration

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "verify": "pnpm typecheck && pnpm build && pnpm test:wave1-deploy-contract && pnpm test:wave1-release-mechanics && pnpm test:wave1-operator-evidence && pnpm test:privileged-execution-bridge && pnpm test:privileged-execution-repair && pnpm test:ui-proof-receipt",
+    "verify": "pnpm typecheck && pnpm build && pnpm test:wave1-deploy-contract && pnpm test:wave1-release-mechanics && pnpm test:wave1-operator-evidence && pnpm test:topology-manifest && pnpm test:privileged-execution-bridge && pnpm test:privileged-execution-repair && pnpm test:ui-proof-receipt",
     "check": "biome check .",
     "format": "biome format --write .",
     "validate:fitness": "node dist/cli.js validate examples/fitness-app.lifeline.yml",
@@ -64,6 +64,7 @@
     "test:wave1-deploy-contract": "node tests/contracts/test-wave1-deploy-contract-deterministic.mjs",
     "test:wave1-release-mechanics": "node scripts/test-wave1-release-mechanics-deterministic.mjs",
     "test:wave1-operator-evidence": "node scripts/test-wave1-operator-evidence-deterministic.mjs",
+    "test:topology-manifest": "node scripts/test-topology-manifest-deterministic.mjs",
     "test:startup-deterministic": "node scripts/test-wave2-startup-deterministic.mjs",
     "test:startup-roundtrip": "node scripts/test-startup-roundtrip-windows-deterministic.mjs",
     "test:privileged-execution-bridge": "node scripts/test-privileged-execution-worker-bridge-deterministic.mjs",

--- a/scripts/test-topology-manifest-deterministic.mjs
+++ b/scripts/test-topology-manifest-deterministic.mjs
@@ -4,12 +4,6 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
-const atlasRoot = path.resolve(repoRoot, "..", "..");
-const topologyManifestPath = path.join(
-  atlasRoot,
-  "docs",
-  "LIFELINE_TOPOLOGY_MANIFEST.json",
-);
 const docsPath = path.join(
   repoRoot,
   "docs",
@@ -18,16 +12,169 @@ const docsPath = path.join(
 );
 const modulePath = path.join(repoRoot, "dist", "core", "topology-manifest.js");
 
+const rawManifest = JSON.stringify({
+  schema_version: "atlas.topology.manifest.v1",
+  source_docs: [
+    "docs/LIFELINE_HOSTING_TOPOLOGY.md",
+    "docs/LIFELINE_ENV_AND_DOMAIN_CONTRACT.md",
+  ],
+  identity: {
+    service_key_template: "{app}/{environment}",
+    stable_public_unit: "app/environment",
+    machine_identity_visibility: "hidden",
+    routing_default: "subdomain-first",
+  },
+  apps: [
+    {
+      app_id: "fitness",
+      repo_id: "fitness",
+      surface: "product",
+      default_zone: "fawxzzy.com",
+      prod_hostname_mode: "default",
+      preview_hostname_mode: "default",
+      pr_preview_hostname_mode: "default",
+    },
+    {
+      app_id: "mazer",
+      repo_id: "mazer",
+      surface: "product",
+      default_zone: "fawxzzy.com",
+      prod_hostname_mode: "default",
+      preview_hostname_mode: "default",
+      pr_preview_hostname_mode: "default",
+    },
+    {
+      app_id: "trove",
+      repo_id: "trove",
+      surface: "product",
+      default_zone: "fawxzzy.com",
+      prod_hostname_mode: "default",
+      preview_hostname_mode: "default",
+      pr_preview_hostname_mode: "default",
+    },
+    {
+      app_id: "lifeline",
+      repo_id: "lifeline",
+      surface: "operator",
+      default_zone: "fawxzzy.com",
+      prod_hostname_mode: "intentional",
+      preview_hostname_mode: "none",
+      pr_preview_hostname_mode: "none",
+    },
+  ],
+  zones: [
+    {
+      zone: "fawxzzy.com",
+      kind: "primary-public",
+      status: "active",
+    },
+  ],
+  environments: {
+    named: [
+      {
+        name: "dev",
+        kind: "local",
+        public_hostname_mode: "none",
+      },
+      {
+        name: "preview",
+        kind: "shared-preview",
+        public_hostname_mode: "default",
+      },
+      {
+        name: "prod",
+        kind: "production",
+        public_hostname_mode: "default",
+      },
+    ],
+    ephemeral: [
+      {
+        kind: "pr",
+        environment_template: "pr-{number}",
+        match: "^pr-[1-9][0-9]*$",
+        public_hostname_mode: "default",
+      },
+    ],
+  },
+  hostname_rules: [
+    {
+      rule_id: "prod",
+      kind: "named",
+      environment: "prod",
+      hostname_template: "{app}.{zone}",
+      service_key_template: "{app}/prod",
+      default_hostname_mode: "default",
+    },
+    {
+      rule_id: "preview",
+      kind: "named",
+      environment: "preview",
+      hostname_template: "preview-{app}.{zone}",
+      service_key_template: "{app}/preview",
+      default_hostname_mode: "default",
+    },
+    {
+      rule_id: "pr-preview",
+      kind: "ephemeral",
+      environment_template: "pr-{number}",
+      hostname_template: "pr-{number}.{app}.{zone}",
+      service_key_template: "{app}/pr-{number}",
+      default_hostname_mode: "default",
+    },
+    {
+      rule_id: "lifeline-prod",
+      kind: "named",
+      environment: "prod",
+      app_id: "lifeline",
+      hostname_template: "lifeline.{zone}",
+      service_key_template: "lifeline/prod",
+      default_hostname_mode: "intentional",
+    },
+  ],
+  routing: {
+    default_strategy: "subdomain-first",
+    path_routing_default: "disallowed-for-distinct-apps",
+    path_routing_allowed_for: [
+      "docs",
+      "admin",
+      "internal-tools",
+      "tightly-coupled-surfaces",
+    ],
+    gateway_resolves_service_before_placement: true,
+    tls_termination: "gateway",
+    cookie_boundary: "application-hostname",
+    public_hostname_must_hide: [
+      "machine_id",
+      "provider_instance_id",
+      "placement",
+    ],
+  },
+  placement: {
+    stable_contract_unit: "app/environment",
+    public_hostname_changes_with_placement: false,
+    default_topology: "shared-gateway-isolated-services",
+    stage_progression: [
+      "single-host-many-services",
+      "shared-gateway-plus-worker-hosts",
+      "lifeline-controlled-multi-host",
+    ],
+    lifeline_v1_exclusions: [
+      "hosted-control-plane",
+      "reverse-proxy-ownership",
+      "domain-automation",
+      "tls-automation",
+      "multi-node-orchestration",
+    ],
+  },
+});
+
 const {
   TOPOLOGY_MANIFEST_SCHEMA_VERSION,
   resolveTopologySurface,
   validateTopologyManifest,
 } = await import(pathToFileURL(modulePath).href);
 
-const [rawManifest, docs] = await Promise.all([
-  readFile(topologyManifestPath, "utf8"),
-  readFile(docsPath, "utf8"),
-]);
+const docs = await readFile(docsPath, "utf8");
 
 const manifest = validateTopologyManifest(JSON.parse(rawManifest));
 

--- a/scripts/test-topology-manifest-deterministic.mjs
+++ b/scripts/test-topology-manifest-deterministic.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const atlasRoot = path.resolve(repoRoot, "..", "..");
+const topologyManifestPath = path.join(
+  atlasRoot,
+  "docs",
+  "LIFELINE_TOPOLOGY_MANIFEST.json",
+);
+const docsPath = path.join(
+  repoRoot,
+  "docs",
+  "contracts",
+  "topology-manifest.md",
+);
+const modulePath = path.join(repoRoot, "dist", "core", "topology-manifest.js");
+
+const {
+  TOPOLOGY_MANIFEST_SCHEMA_VERSION,
+  resolveTopologySurface,
+  validateTopologyManifest,
+} = await import(pathToFileURL(modulePath).href);
+
+const [rawManifest, docs] = await Promise.all([
+  readFile(topologyManifestPath, "utf8"),
+  readFile(docsPath, "utf8"),
+]);
+
+const manifest = validateTopologyManifest(JSON.parse(rawManifest));
+
+assert.equal(manifest.schema_version, TOPOLOGY_MANIFEST_SCHEMA_VERSION);
+assert.deepEqual(manifest.source_docs, [
+  "docs/LIFELINE_HOSTING_TOPOLOGY.md",
+  "docs/LIFELINE_ENV_AND_DOMAIN_CONTRACT.md",
+]);
+
+const troveProd = resolveTopologySurface(manifest, "trove", "prod");
+assert.equal(troveProd.serviceKey, "trove/prod");
+assert.equal(troveProd.hostname, "trove.fawxzzy.com");
+assert.equal(troveProd.publicHostnameMode, "default");
+assert.equal(troveProd.ruleId, "prod");
+
+const trovePreview = resolveTopologySurface(manifest, "trove", "preview");
+assert.equal(trovePreview.serviceKey, "trove/preview");
+assert.equal(trovePreview.hostname, "preview-trove.fawxzzy.com");
+assert.equal(trovePreview.publicHostnameMode, "default");
+assert.equal(trovePreview.ruleId, "preview");
+
+const trovePr = resolveTopologySurface(manifest, "trove", "pr-18");
+assert.equal(trovePr.environmentKind, "ephemeral");
+assert.equal(trovePr.serviceKey, "trove/pr-18");
+assert.equal(trovePr.hostname, "pr-18.trove.fawxzzy.com");
+assert.equal(trovePr.publicHostnameMode, "default");
+assert.equal(trovePr.ruleId, "pr-preview");
+
+const fitnessDev = resolveTopologySurface(manifest, "fitness", "dev");
+assert.equal(fitnessDev.serviceKey, "fitness/dev");
+assert.equal(fitnessDev.hostname, undefined);
+assert.equal(fitnessDev.publicHostnameMode, "none");
+assert.equal(fitnessDev.ruleId, undefined);
+
+const lifelineProd = resolveTopologySurface(manifest, "lifeline", "prod");
+assert.equal(lifelineProd.serviceKey, "lifeline/prod");
+assert.equal(lifelineProd.hostname, "lifeline.fawxzzy.com");
+assert.equal(lifelineProd.publicHostnameMode, "intentional");
+assert.equal(lifelineProd.ruleId, "lifeline-prod");
+
+const lifelinePreview = resolveTopologySurface(
+  manifest,
+  "lifeline",
+  "preview",
+);
+assert.equal(lifelinePreview.serviceKey, "lifeline/preview");
+assert.equal(lifelinePreview.hostname, undefined);
+assert.equal(lifelinePreview.publicHostnameMode, "none");
+assert.equal(lifelinePreview.ruleId, "preview");
+
+assert.throws(
+  () => resolveTopologySurface(manifest, "trove", "qa"),
+  /Unknown topology environment "qa"\./,
+);
+assert.throws(
+  () => resolveTopologySurface(manifest, "unknown-app", "prod"),
+  /Unknown topology app "unknown-app"\./,
+);
+
+assert(
+  docs.includes("atlas.topology.manifest.v1") &&
+    docs.includes("ATLAS-owned topology manifest") &&
+    docs.includes("app/environment") &&
+    docs.includes("domain automation") &&
+    docs.includes("TLS automation"),
+  "topology-manifest doc must describe the intake boundary and exclusions",
+);
+
+console.log("Topology manifest deterministic verification passed.");

--- a/src/core/topology-manifest.ts
+++ b/src/core/topology-manifest.ts
@@ -1,0 +1,783 @@
+import { ValidationError } from "./errors.js";
+
+export const TOPOLOGY_MANIFEST_SCHEMA_VERSION = "atlas.topology.manifest.v1";
+
+export interface TopologyIdentity {
+  service_key_template: string;
+  stable_public_unit: string;
+  machine_identity_visibility: string;
+  routing_default: string;
+}
+
+export interface TopologyApp {
+  app_id: string;
+  repo_id: string;
+  surface: string;
+  default_zone: string;
+  prod_hostname_mode: string;
+  preview_hostname_mode: string;
+  pr_preview_hostname_mode: string;
+}
+
+export interface TopologyZone {
+  zone: string;
+  kind: string;
+  status: string;
+}
+
+export interface NamedTopologyEnvironment {
+  name: string;
+  kind: string;
+  public_hostname_mode: string;
+}
+
+export interface EphemeralTopologyEnvironment {
+  kind: string;
+  environment_template: string;
+  match: string;
+  public_hostname_mode: string;
+}
+
+export interface TopologyEnvironments {
+  named: NamedTopologyEnvironment[];
+  ephemeral: EphemeralTopologyEnvironment[];
+}
+
+export interface TopologyHostnameRule {
+  rule_id: string;
+  kind: string;
+  environment?: string;
+  environment_template?: string;
+  app_id?: string;
+  hostname_template: string;
+  service_key_template: string;
+  default_hostname_mode: string;
+}
+
+export interface TopologyRouting {
+  default_strategy: string;
+  path_routing_default: string;
+  path_routing_allowed_for: string[];
+  gateway_resolves_service_before_placement: boolean;
+  tls_termination: string;
+  cookie_boundary: string;
+  public_hostname_must_hide: string[];
+}
+
+export interface TopologyPlacement {
+  stable_contract_unit: string;
+  public_hostname_changes_with_placement: boolean;
+  default_topology: string;
+  stage_progression: string[];
+  lifeline_v1_exclusions: string[];
+}
+
+export interface TopologyManifest {
+  schema_version: string;
+  source_docs: string[];
+  identity: TopologyIdentity;
+  apps: TopologyApp[];
+  zones: TopologyZone[];
+  environments: TopologyEnvironments;
+  hostname_rules: TopologyHostnameRule[];
+  routing: TopologyRouting;
+  placement: TopologyPlacement;
+}
+
+export interface ResolvedTopologySurface {
+  appId: string;
+  environment: string;
+  environmentKind: "named" | "ephemeral";
+  zone: string;
+  serviceKey: string;
+  publicHostnameMode: string;
+  hostname?: string;
+  ruleId?: string;
+}
+
+interface MatchedEnvironment {
+  kind: "named" | "ephemeral";
+  publicHostnameMode: string;
+  variables: Record<string, string>;
+  definition: NamedTopologyEnvironment | EphemeralTopologyEnvironment;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function expectRecord(value: unknown, path: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new ValidationError(`${path} must be an object.`);
+  }
+
+  return value;
+}
+
+function expectString(value: unknown, path: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new ValidationError(`${path} must be a non-empty string.`);
+  }
+
+  return value;
+}
+
+function expectBoolean(value: unknown, path: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new ValidationError(`${path} must be a boolean.`);
+  }
+
+  return value;
+}
+
+function expectArray(value: unknown, path: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new ValidationError(`${path} must be an array.`);
+  }
+
+  return value;
+}
+
+function expectStringArray(value: unknown, path: string): string[] {
+  return expectArray(value, path).map((entry, index) =>
+    expectString(entry, `${path}[${index}]`),
+  );
+}
+
+function assertAllowedKeys(
+  value: Record<string, unknown>,
+  allowedKeys: string[],
+  path: string,
+): void {
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.includes(key)) {
+      throw new ValidationError(
+        `${path} contains unsupported key "${key}".`,
+      );
+    }
+  }
+}
+
+function parseIdentity(value: unknown, path: string): TopologyIdentity {
+  const record = expectRecord(value, path);
+  assertAllowedKeys(
+    record,
+    [
+      "service_key_template",
+      "stable_public_unit",
+      "machine_identity_visibility",
+      "routing_default",
+    ],
+    path,
+  );
+
+  return {
+    service_key_template: expectString(
+      record.service_key_template,
+      `${path}.service_key_template`,
+    ),
+    stable_public_unit: expectString(
+      record.stable_public_unit,
+      `${path}.stable_public_unit`,
+    ),
+    machine_identity_visibility: expectString(
+      record.machine_identity_visibility,
+      `${path}.machine_identity_visibility`,
+    ),
+    routing_default: expectString(
+      record.routing_default,
+      `${path}.routing_default`,
+    ),
+  };
+}
+
+function parseApp(value: unknown, path: string): TopologyApp {
+  const record = expectRecord(value, path);
+  assertAllowedKeys(
+    record,
+    [
+      "app_id",
+      "repo_id",
+      "surface",
+      "default_zone",
+      "prod_hostname_mode",
+      "preview_hostname_mode",
+      "pr_preview_hostname_mode",
+    ],
+    path,
+  );
+
+  return {
+    app_id: expectString(record.app_id, `${path}.app_id`),
+    repo_id: expectString(record.repo_id, `${path}.repo_id`),
+    surface: expectString(record.surface, `${path}.surface`),
+    default_zone: expectString(record.default_zone, `${path}.default_zone`),
+    prod_hostname_mode: expectString(
+      record.prod_hostname_mode,
+      `${path}.prod_hostname_mode`,
+    ),
+    preview_hostname_mode: expectString(
+      record.preview_hostname_mode,
+      `${path}.preview_hostname_mode`,
+    ),
+    pr_preview_hostname_mode: expectString(
+      record.pr_preview_hostname_mode,
+      `${path}.pr_preview_hostname_mode`,
+    ),
+  };
+}
+
+function parseZone(value: unknown, path: string): TopologyZone {
+  const record = expectRecord(value, path);
+  assertAllowedKeys(record, ["zone", "kind", "status"], path);
+
+  return {
+    zone: expectString(record.zone, `${path}.zone`),
+    kind: expectString(record.kind, `${path}.kind`),
+    status: expectString(record.status, `${path}.status`),
+  };
+}
+
+function parseNamedEnvironment(
+  value: unknown,
+  path: string,
+): NamedTopologyEnvironment {
+  const record = expectRecord(value, path);
+  assertAllowedKeys(record, ["name", "kind", "public_hostname_mode"], path);
+
+  return {
+    name: expectString(record.name, `${path}.name`),
+    kind: expectString(record.kind, `${path}.kind`),
+    public_hostname_mode: expectString(
+      record.public_hostname_mode,
+      `${path}.public_hostname_mode`,
+    ),
+  };
+}
+
+function parseEphemeralEnvironment(
+  value: unknown,
+  path: string,
+): EphemeralTopologyEnvironment {
+  const record = expectRecord(value, path);
+  assertAllowedKeys(
+    record,
+    ["kind", "environment_template", "match", "public_hostname_mode"],
+    path,
+  );
+
+  return {
+    kind: expectString(record.kind, `${path}.kind`),
+    environment_template: expectString(
+      record.environment_template,
+      `${path}.environment_template`,
+    ),
+    match: expectString(record.match, `${path}.match`),
+    public_hostname_mode: expectString(
+      record.public_hostname_mode,
+      `${path}.public_hostname_mode`,
+    ),
+  };
+}
+
+function parseEnvironments(
+  value: unknown,
+  path: string,
+): TopologyEnvironments {
+  const record = expectRecord(value, path);
+  assertAllowedKeys(record, ["named", "ephemeral"], path);
+
+  return {
+    named: expectArray(record.named, `${path}.named`).map((entry, index) =>
+      parseNamedEnvironment(entry, `${path}.named[${index}]`),
+    ),
+    ephemeral: expectArray(record.ephemeral, `${path}.ephemeral`).map(
+      (entry, index) =>
+        parseEphemeralEnvironment(entry, `${path}.ephemeral[${index}]`),
+    ),
+  };
+}
+
+function parseHostnameRule(
+  value: unknown,
+  path: string,
+): TopologyHostnameRule {
+  const record = expectRecord(value, path);
+  assertAllowedKeys(
+    record,
+    [
+      "rule_id",
+      "kind",
+      "environment",
+      "environment_template",
+      "app_id",
+      "hostname_template",
+      "service_key_template",
+      "default_hostname_mode",
+    ],
+    path,
+  );
+
+  const kind = expectString(record.kind, `${path}.kind`);
+  const environment =
+    record.environment === undefined
+      ? undefined
+      : expectString(record.environment, `${path}.environment`);
+  const environmentTemplate =
+    record.environment_template === undefined
+      ? undefined
+      : expectString(
+          record.environment_template,
+          `${path}.environment_template`,
+        );
+
+  if (kind === "named" && !environment) {
+    throw new ValidationError(
+      `${path}.environment is required for named hostname rules.`,
+    );
+  }
+
+  if (kind === "ephemeral" && !environmentTemplate) {
+    throw new ValidationError(
+      `${path}.environment_template is required for ephemeral hostname rules.`,
+    );
+  }
+
+  return {
+    rule_id: expectString(record.rule_id, `${path}.rule_id`),
+    kind,
+    ...(environment ? { environment } : {}),
+    ...(environmentTemplate
+      ? { environment_template: environmentTemplate }
+      : {}),
+    ...(record.app_id === undefined
+      ? {}
+      : { app_id: expectString(record.app_id, `${path}.app_id`) }),
+    hostname_template: expectString(
+      record.hostname_template,
+      `${path}.hostname_template`,
+    ),
+    service_key_template: expectString(
+      record.service_key_template,
+      `${path}.service_key_template`,
+    ),
+    default_hostname_mode: expectString(
+      record.default_hostname_mode,
+      `${path}.default_hostname_mode`,
+    ),
+  };
+}
+
+function parseRouting(value: unknown, path: string): TopologyRouting {
+  const record = expectRecord(value, path);
+  assertAllowedKeys(
+    record,
+    [
+      "default_strategy",
+      "path_routing_default",
+      "path_routing_allowed_for",
+      "gateway_resolves_service_before_placement",
+      "tls_termination",
+      "cookie_boundary",
+      "public_hostname_must_hide",
+    ],
+    path,
+  );
+
+  return {
+    default_strategy: expectString(
+      record.default_strategy,
+      `${path}.default_strategy`,
+    ),
+    path_routing_default: expectString(
+      record.path_routing_default,
+      `${path}.path_routing_default`,
+    ),
+    path_routing_allowed_for: expectStringArray(
+      record.path_routing_allowed_for,
+      `${path}.path_routing_allowed_for`,
+    ),
+    gateway_resolves_service_before_placement: expectBoolean(
+      record.gateway_resolves_service_before_placement,
+      `${path}.gateway_resolves_service_before_placement`,
+    ),
+    tls_termination: expectString(
+      record.tls_termination,
+      `${path}.tls_termination`,
+    ),
+    cookie_boundary: expectString(
+      record.cookie_boundary,
+      `${path}.cookie_boundary`,
+    ),
+    public_hostname_must_hide: expectStringArray(
+      record.public_hostname_must_hide,
+      `${path}.public_hostname_must_hide`,
+    ),
+  };
+}
+
+function parsePlacement(value: unknown, path: string): TopologyPlacement {
+  const record = expectRecord(value, path);
+  assertAllowedKeys(
+    record,
+    [
+      "stable_contract_unit",
+      "public_hostname_changes_with_placement",
+      "default_topology",
+      "stage_progression",
+      "lifeline_v1_exclusions",
+    ],
+    path,
+  );
+
+  return {
+    stable_contract_unit: expectString(
+      record.stable_contract_unit,
+      `${path}.stable_contract_unit`,
+    ),
+    public_hostname_changes_with_placement: expectBoolean(
+      record.public_hostname_changes_with_placement,
+      `${path}.public_hostname_changes_with_placement`,
+    ),
+    default_topology: expectString(
+      record.default_topology,
+      `${path}.default_topology`,
+    ),
+    stage_progression: expectStringArray(
+      record.stage_progression,
+      `${path}.stage_progression`,
+    ),
+    lifeline_v1_exclusions: expectStringArray(
+      record.lifeline_v1_exclusions,
+      `${path}.lifeline_v1_exclusions`,
+    ),
+  };
+}
+
+function assertUniqueStrings(values: string[], path: string): void {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) {
+      throw new ValidationError(`${path} must not contain duplicates: ${value}.`);
+    }
+    seen.add(value);
+  }
+}
+
+function compileEnvironmentTemplate(template: string): RegExp {
+  const pattern = template.replace(
+    /\{([a-zA-Z0-9_]+)\}/g,
+    (_, name: string) => `(?<${name}>[^.\\/]+)`,
+  );
+  return new RegExp(`^${pattern}$`);
+}
+
+function matchEnvironment(
+  manifest: TopologyManifest,
+  environment: string,
+): MatchedEnvironment {
+  const named = manifest.environments.named.find(
+    (entry) => entry.name === environment,
+  );
+  if (named) {
+    return {
+      kind: "named",
+      publicHostnameMode: named.public_hostname_mode,
+      variables: {},
+      definition: named,
+    };
+  }
+
+  for (const entry of manifest.environments.ephemeral) {
+    const matcher = new RegExp(entry.match);
+    if (!matcher.test(environment)) {
+      continue;
+    }
+
+    const templateMatch = compileEnvironmentTemplate(
+      entry.environment_template,
+    ).exec(environment);
+
+    return {
+      kind: "ephemeral",
+      publicHostnameMode: entry.public_hostname_mode,
+      variables: templateMatch?.groups
+        ? Object.fromEntries(Object.entries(templateMatch.groups))
+        : {},
+      definition: entry,
+    };
+  }
+
+  throw new ValidationError(
+    `Unknown topology environment "${environment}".`,
+  );
+}
+
+function resolvePublicHostnameMode(
+  app: TopologyApp,
+  environment: string,
+  matchedEnvironment: MatchedEnvironment,
+): string {
+  if (matchedEnvironment.kind === "ephemeral") {
+    return app.pr_preview_hostname_mode;
+  }
+
+  if (environment === "prod") {
+    return app.prod_hostname_mode;
+  }
+
+  if (environment === "preview") {
+    return app.preview_hostname_mode;
+  }
+
+  return matchedEnvironment.publicHostnameMode;
+}
+
+function applyTemplate(
+  template: string,
+  values: Record<string, string>,
+  path: string,
+): string {
+  return template.replace(/\{([a-zA-Z0-9_]+)\}/g, (_, key: string) => {
+    const resolved = values[key];
+    if (!resolved) {
+      throw new ValidationError(
+        `${path} references missing template value "${key}".`,
+      );
+    }
+    return resolved;
+  });
+}
+
+function selectHostnameRule(
+  manifest: TopologyManifest,
+  appId: string,
+  environment: string,
+  matchedEnvironment: MatchedEnvironment,
+): TopologyHostnameRule | undefined {
+  const candidates = manifest.hostname_rules.filter((rule) => {
+    if (rule.kind !== matchedEnvironment.kind) {
+      return false;
+    }
+
+    if (matchedEnvironment.kind === "named" && rule.environment !== environment) {
+      return false;
+    }
+
+    if (
+      matchedEnvironment.kind === "ephemeral" &&
+      rule.environment_template !==
+        (matchedEnvironment.definition as EphemeralTopologyEnvironment)
+          .environment_template
+    ) {
+      return false;
+    }
+
+    if (rule.app_id && rule.app_id !== appId) {
+      return false;
+    }
+
+    return true;
+  });
+
+  candidates.sort((left, right) => {
+    const leftSpecificity = left.app_id ? 1 : 0;
+    const rightSpecificity = right.app_id ? 1 : 0;
+    return rightSpecificity - leftSpecificity;
+  });
+
+  return candidates[0];
+}
+
+function validateManifestRelationships(manifest: TopologyManifest): void {
+  assertUniqueStrings(
+    manifest.apps.map((entry) => entry.app_id),
+    "apps.app_id",
+  );
+  assertUniqueStrings(
+    manifest.zones.map((entry) => entry.zone),
+    "zones.zone",
+  );
+  assertUniqueStrings(
+    manifest.environments.named.map((entry) => entry.name),
+    "environments.named.name",
+  );
+  assertUniqueStrings(
+    manifest.hostname_rules.map((entry) => entry.rule_id),
+    "hostname_rules.rule_id",
+  );
+
+  const zoneNames = new Set(manifest.zones.map((entry) => entry.zone));
+  for (const app of manifest.apps) {
+    if (!zoneNames.has(app.default_zone)) {
+      throw new ValidationError(
+        `App ${app.app_id} references unknown zone ${app.default_zone}.`,
+      );
+    }
+  }
+
+  const appIds = new Set(manifest.apps.map((entry) => entry.app_id));
+  const namedEnvironmentNames = new Set(
+    manifest.environments.named.map((entry) => entry.name),
+  );
+  const ephemeralTemplates = new Set(
+    manifest.environments.ephemeral.map((entry) => entry.environment_template),
+  );
+
+  for (const rule of manifest.hostname_rules) {
+    if (rule.app_id && !appIds.has(rule.app_id)) {
+      throw new ValidationError(
+        `Hostname rule ${rule.rule_id} references unknown app ${rule.app_id}.`,
+      );
+    }
+
+    if (rule.kind === "named") {
+      if (!rule.environment || !namedEnvironmentNames.has(rule.environment)) {
+        throw new ValidationError(
+          `Hostname rule ${rule.rule_id} references unknown named environment ${rule.environment ?? "<missing>"}.`,
+        );
+      }
+    }
+
+    if (rule.kind === "ephemeral") {
+      if (
+        !rule.environment_template ||
+        !ephemeralTemplates.has(rule.environment_template)
+      ) {
+        throw new ValidationError(
+          `Hostname rule ${rule.rule_id} references unknown ephemeral environment template ${rule.environment_template ?? "<missing>"}.`,
+        );
+      }
+    }
+  }
+}
+
+export function validateTopologyManifest(input: unknown): TopologyManifest {
+  const record = expectRecord(input, "topologyManifest");
+  assertAllowedKeys(
+    record,
+    [
+      "schema_version",
+      "source_docs",
+      "identity",
+      "apps",
+      "zones",
+      "environments",
+      "hostname_rules",
+      "routing",
+      "placement",
+    ],
+    "topologyManifest",
+  );
+
+  const manifest: TopologyManifest = {
+    schema_version: expectString(
+      record.schema_version,
+      "topologyManifest.schema_version",
+    ),
+    source_docs: expectStringArray(
+      record.source_docs,
+      "topologyManifest.source_docs",
+    ),
+    identity: parseIdentity(record.identity, "topologyManifest.identity"),
+    apps: expectArray(record.apps, "topologyManifest.apps").map((entry, index) =>
+      parseApp(entry, `topologyManifest.apps[${index}]`),
+    ),
+    zones: expectArray(record.zones, "topologyManifest.zones").map(
+      (entry, index) => parseZone(entry, `topologyManifest.zones[${index}]`),
+    ),
+    environments: parseEnvironments(
+      record.environments,
+      "topologyManifest.environments",
+    ),
+    hostname_rules: expectArray(
+      record.hostname_rules,
+      "topologyManifest.hostname_rules",
+    ).map((entry, index) =>
+      parseHostnameRule(entry, `topologyManifest.hostname_rules[${index}]`),
+    ),
+    routing: parseRouting(record.routing, "topologyManifest.routing"),
+    placement: parsePlacement(record.placement, "topologyManifest.placement"),
+  };
+
+  if (manifest.schema_version !== TOPOLOGY_MANIFEST_SCHEMA_VERSION) {
+    throw new ValidationError(
+      `Unsupported topology manifest schema version ${manifest.schema_version}. Supported version: ${TOPOLOGY_MANIFEST_SCHEMA_VERSION}.`,
+    );
+  }
+
+  validateManifestRelationships(manifest);
+
+  return manifest;
+}
+
+export function resolveTopologySurface(
+  manifest: TopologyManifest,
+  appId: string,
+  environment: string,
+): ResolvedTopologySurface {
+  const app = manifest.apps.find((entry) => entry.app_id === appId);
+  if (!app) {
+    throw new ValidationError(`Unknown topology app "${appId}".`);
+  }
+
+  const matchedEnvironment = matchEnvironment(manifest, environment);
+  const publicHostnameMode = resolvePublicHostnameMode(
+    app,
+    environment,
+    matchedEnvironment,
+  );
+  const rule = selectHostnameRule(
+    manifest,
+    appId,
+    environment,
+    matchedEnvironment,
+  );
+  const zone = app.default_zone;
+  const templateValues = {
+    app: app.app_id,
+    environment,
+    zone,
+    ...matchedEnvironment.variables,
+  };
+  const serviceKeyTemplate =
+    rule?.service_key_template ?? manifest.identity.service_key_template;
+  const serviceKey = applyTemplate(
+    serviceKeyTemplate,
+    templateValues,
+    "service_key_template",
+  );
+
+  if (publicHostnameMode === "none") {
+    return {
+      appId: app.app_id,
+      environment,
+      environmentKind: matchedEnvironment.kind,
+      zone,
+      serviceKey,
+      publicHostnameMode,
+      ...(rule ? { ruleId: rule.rule_id } : {}),
+    };
+  }
+
+  if (!rule) {
+    throw new ValidationError(
+      `No hostname rule found for ${appId}/${environment}.`,
+    );
+  }
+
+  return {
+    appId: app.app_id,
+    environment,
+    environmentKind: matchedEnvironment.kind,
+    zone,
+    serviceKey,
+    publicHostnameMode,
+    hostname: applyTemplate(
+      rule.hostname_template,
+      templateValues,
+      `${rule.rule_id}.hostname_template`,
+    ),
+    ruleId: rule.rule_id,
+  };
+}


### PR DESCRIPTION
## Summary

- add a Lifeline-side validator for the ATLAS-owned topology manifest
- resolve stable `app/environment` service identity and hostname intent
- cover named environments, PR environments, app-specific Lifeline hostname exceptions, and local-only dev behavior
- document that Lifeline consumes topology truth without owning DNS, TLS, reverse-proxy automation, hosted control plane behavior, or multi-node orchestration
- wire deterministic topology validation into `pnpm run verify`

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run verify`

## Scope note

This is a topology contract intake slice only. It does not claim live preview infrastructure exists, does not reopen the Trove preview-host loop, and does not widen Lifeline into domain/TLS automation.