### PR TITLE
Lifeline: add release CLI surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Lifeline provides a boring, low-maintenance way to describe how an app should be
 - A home for a small, explicit app manifest contract.
 - A file-based config resolver that can optionally read Playbook archetype exports from a local checkout.
 - A runtime slice that can `resolve`, `up`, `down`, `status`, `logs`, `restart`, `restore`, `startup`, and `validate` one app on one machine.
+- A local-first Wave 1 release surface that can `release plan`, `release persist`, `release activate`, and `release rollback` against the existing deploy manifest contract.
 - A narrow capability-backed execution surface that can `execute` read-only inspections and dry-run commands with receipts.
 - A narrow proof-backed receipt surface that can emit auditable `proof_passed` receipts from ATLAS UI proof summaries.
 - Fixture-based smoke paths that verify manifest-only runtime behavior and Playbook-backed resolution without depending on an external Playbook repo.
@@ -79,6 +80,10 @@ pnpm lifeline restore
 pnpm lifeline startup status
 pnpm lifeline startup enable
 pnpm lifeline startup disable
+pnpm lifeline release plan control-plane/fixtures/wave1-pilot-deploy.manifest.json
+pnpm lifeline release persist control-plane/fixtures/wave1-pilot-deploy.manifest.json
+pnpm lifeline release activate lifeline-pilot <release-id>
+pnpm lifeline release rollback lifeline-pilot
 pnpm lifeline execute examples/privileged-execution/read-only-scan.request.json \
   --capability-profile examples/privileged-execution/capability-profile.json \
   --approval-receipt examples/privileged-execution/read-only-scan.approval.json
@@ -100,6 +105,7 @@ Use the operator path in this order so environment drift, manifest drift, and re
 2. `pnpm lifeline validate <manifest> [--playbook-path <path>]`
 3. the intended runtime action (`up`, `restart`, `status`, or `execute`)
 4. the auditable receipt step (`execute` writes an execution receipt for every attempt; `proof-pass` writes a deterministic `proof_passed` receipt when the referenced ATLAS summary is clean and `completion_ready=true`)
+5. when release state must move, use the bounded release lane (`release plan`, `release persist`, `release activate`, `release rollback`) against the existing deploy manifest contract
 
 - Rule: validation must execute through the same CLI boundary operators use for real runtime-facing work.
 - Pattern: run the shared preflight first, validate through the canonical CLI boundary second, then emit deterministic receipts with an explicit first remediation step when receipt emission is blocked.
@@ -159,6 +165,10 @@ Playbook archetype exports are sparse optional default bundles. They may omit an
 - The runtime `port` requirement can come from either Playbook defaults or explicit manifest values.
 - `lifeline resolve <manifest>` prints the fully resolved config that Lifeline would execute.
 - `lifeline up` and `lifeline restart` use the same resolution path as `resolve`.
+- `lifeline release plan <deploy-manifest>` previews the normalized release metadata, deterministic release id, and local `.lifeline/releases/<app>/...` layout without writing state.
+- `lifeline release persist <deploy-manifest>` writes immutable release metadata plus a planned receipt under `.lifeline/releases/<app>/receipts/`.
+- `lifeline release activate <app> <release-id>` promotes one persisted release id to current and records activation lineage locally.
+- `lifeline release rollback <app>` promotes the previous known-good release back to current and emits a rollback receipt.
 - The standalone `scripts/validate-fitness-mirror.mjs` helper delegates to `lifeline validate` so mirror validation uses the same CLI boundary as normal runtime-facing validation paths instead of importing temp-transpiled outputs.
 - If an app was started with Playbook defaults, Lifeline stores the resolved Playbook path in `.lifeline/state.json` so `restart` remains deterministic without retyping flags.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,6 +47,7 @@ The CLI is the operator-facing entrypoint. Current commands:
 - `restart`
 - `restore`
 - `startup` (merged Wave 2 backend seam with registered platform installers)
+- `release`
 - `execute`
 - `proof-pass`
 
@@ -79,6 +80,15 @@ Wave 1 release planning and activation stay local-first:
 - plan, activation, failed activation, and rollback each emit receipts keyed to concrete release ids
 
 This is the first execution slice that replaces "deploy a branch" with "deploy a concrete release target" without introducing hosted control-plane behavior.
+
+The operator-facing release CLI stays narrow:
+
+- `lifeline release plan <deploy-manifest>`
+- `lifeline release persist <deploy-manifest>`
+- `lifeline release activate <app-name> <release-id>`
+- `lifeline release rollback <app-name>`
+
+This surface is intentionally local-only. It does not add domain automation, TLS automation, preview-host assumptions, hosted control-plane behavior, or app-specific special casing.
 
 ## 7. Receipt-backed execution and proof surfaces
 

--- a/docs/ops/lifeline-operator-surface.md
+++ b/docs/ops/lifeline-operator-surface.md
@@ -10,6 +10,7 @@ Run the operator flow in this order:
 2. `pnpm lifeline validate <manifest> [--playbook-path <path>]`
 3. runtime action (`up`, `restart`, `status`, or `execute`)
 4. receipt step (`execute` receipt or `proof-pass` receipt)
+5. release step when the concrete release target must move (`release plan`, `release persist`, `release activate`, `release rollback`)
 
 Why this order matters:
 
@@ -64,6 +65,14 @@ Useful signals:
 - `lifeline proof-pass` writes a deterministic `proof_passed` receipt only when the referenced ATLAS proof summary is clean and `completion_ready=true`.
 - Receipt failures print a failure category plus the first remediation step so the operator can stop on the real root cause.
 - Path-like refs are normalized before write so receipts stay diffable across Windows and POSIX environments.
+
+## Release contract
+
+- `lifeline release plan <deploy-manifest>` previews the deterministic release id and local `.lifeline/releases/<app>/...` layout without writing state.
+- `lifeline release persist <deploy-manifest>` writes immutable release metadata and a planned receipt.
+- `lifeline release activate <app-name> <release-id>` advances the current release pointer to one persisted release id.
+- `lifeline release rollback <app-name>` promotes the previous known-good release back to current.
+- This lane is local-first and bounded. It does not imply preview hosts, domain automation, TLS automation, or hosted control-plane behavior.
 
 ## Smoke-check path
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "verify": "pnpm typecheck && pnpm build && pnpm test:wave1-deploy-contract && pnpm test:wave1-release-mechanics && pnpm test:wave1-operator-evidence && pnpm test:topology-manifest && pnpm test:privileged-execution-bridge && pnpm test:privileged-execution-repair && pnpm test:ui-proof-receipt",
+    "verify": "pnpm typecheck && pnpm build && pnpm test:wave1-deploy-contract && pnpm test:wave1-release-mechanics && pnpm test:wave1-release-cli && pnpm test:wave1-operator-evidence && pnpm test:topology-manifest && pnpm test:privileged-execution-bridge && pnpm test:privileged-execution-repair && pnpm test:ui-proof-receipt",
     "check": "biome check .",
     "format": "biome format --write .",
     "validate:fitness": "node dist/cli.js validate examples/fitness-app.lifeline.yml",
@@ -63,6 +63,7 @@
     "smoke:runtime:restore-missing-env-file": "node scripts/smoke-runtime-restore-missing-env-file.mjs",
     "test:wave1-deploy-contract": "node tests/contracts/test-wave1-deploy-contract-deterministic.mjs",
     "test:wave1-release-mechanics": "node scripts/test-wave1-release-mechanics-deterministic.mjs",
+    "test:wave1-release-cli": "node scripts/test-wave1-release-cli-deterministic.mjs",
     "test:wave1-operator-evidence": "node scripts/test-wave1-operator-evidence-deterministic.mjs",
     "test:topology-manifest": "node scripts/test-topology-manifest-deterministic.mjs",
     "test:startup-deterministic": "node scripts/test-wave2-startup-deterministic.mjs",

--- a/scripts/test-readme-command-surface-deterministic.mjs
+++ b/scripts/test-readme-command-surface-deterministic.mjs
@@ -153,6 +153,7 @@ async function main() {
     'restart',
     'restore',
     'startup',
+    'release',
     'execute',
     'proof-pass',
     'down',

--- a/scripts/test-wave1-release-cli-deterministic.mjs
+++ b/scripts/test-wave1-release-cli-deterministic.mjs
@@ -1,0 +1,160 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { strict as assert } from "node:assert";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { ensureBuilt } from "./lib/ensure-built.mjs";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const cliPath = path.join(repoRoot, "dist", "cli.js");
+const fixtureManifestPath = path.join(
+  repoRoot,
+  "control-plane",
+  "fixtures",
+  "wave1-pilot-deploy.manifest.json",
+);
+
+function parseJsonOutput(output) {
+  return JSON.parse(output);
+}
+
+async function runCli(cwd, args) {
+  try {
+    const { stdout, stderr } = await execFileAsync(process.execPath, [cliPath, ...args], {
+      cwd,
+      env: process.env,
+    });
+    return { code: 0, stdout, stderr };
+  } catch (error) {
+    const exitError = /** @type {{ code?: number; stdout?: string; stderr?: string }} */ (error);
+    return {
+      code: typeof exitError.code === "number" ? exitError.code : 1,
+      stdout: exitError.stdout ?? "",
+      stderr: exitError.stderr ?? "",
+    };
+  }
+}
+
+await ensureBuilt();
+
+const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lifeline-release-cli-"));
+
+try {
+  const missingAction = await runCli(tempRoot, ["release"]);
+  assert.equal(missingAction.code, 1);
+  assert.match(
+    missingAction.stderr,
+    /Missing release action\. Use one of: plan, persist, activate, rollback\./,
+  );
+
+  const missingManifest = await runCli(tempRoot, ["release", "plan"]);
+  assert.equal(missingManifest.code, 1);
+  assert.match(missingManifest.stderr, /Missing deploy manifest path\./);
+
+  const planResult = await runCli(tempRoot, [
+    "release",
+    "plan",
+    fixtureManifestPath,
+  ]);
+  assert.equal(planResult.code, 0, planResult.stderr);
+  const planned = parseJsonOutput(planResult.stdout);
+  assert.equal(planned.validation.status, "passed");
+  assert.equal(planned.appName, "lifeline-pilot");
+  assert.equal(planned.releaseMetadata.releaseTarget.kind, "single-host-immutable");
+  assert.equal(planned.rootDir.replace(/\\/g, "/"), tempRoot.replace(/\\/g, "/"));
+
+  const persistedResult = await runCli(tempRoot, [
+    "release",
+    "persist",
+    fixtureManifestPath,
+  ]);
+  assert.equal(persistedResult.code, 0, persistedResult.stderr);
+  const persisted = parseJsonOutput(persistedResult.stdout);
+  assert.equal(persisted.validation.status, "passed");
+  assert.equal(persisted.receipt.action, "planned");
+  assert.equal(persisted.receipt.status, "planned");
+
+  const firstReleaseId = persisted.releaseId;
+  const firstMetadataPath = path.join(
+    tempRoot,
+    ".lifeline",
+    "releases",
+    "lifeline-pilot",
+    firstReleaseId,
+    "metadata.json",
+  );
+  const firstMetadata = JSON.parse(await readFile(firstMetadataPath, "utf8"));
+  assert.equal(firstMetadata.releaseId, firstReleaseId);
+
+  const activateFirstResult = await runCli(tempRoot, [
+    "release",
+    "activate",
+    "lifeline-pilot",
+    firstReleaseId,
+  ]);
+  assert.equal(activateFirstResult.code, 0, activateFirstResult.stderr);
+  const activatedFirst = parseJsonOutput(activateFirstResult.stdout);
+  assert.equal(activatedFirst.ok, true);
+  assert.equal(activatedFirst.current.releaseId, firstReleaseId);
+  assert.equal(activatedFirst.receipt.action, "activate");
+  assert.equal(activatedFirst.receipt.status, "succeeded");
+
+  const secondManifestPath = path.join(tempRoot, "wave1-pilot-deploy-2.manifest.json");
+  const secondManifest = JSON.parse(await readFile(fixtureManifestPath, "utf8"));
+  secondManifest.imageRef =
+    "ghcr.io/fawxzzy/lifeline-pilot@sha256:22223333444455556666777788889999aaaabbbbccccddddeeeeffff00001111";
+  secondManifest.rollbackTarget.releaseId = firstReleaseId;
+  secondManifest.rollbackTarget.artifactRef = firstMetadata.artifactRef;
+  secondManifest.rollbackTarget.strategy = "restore";
+  await writeFile(secondManifestPath, JSON.stringify(secondManifest, null, 2), "utf8");
+
+  const persistSecondResult = await runCli(tempRoot, [
+    "release",
+    "persist",
+    secondManifestPath,
+  ]);
+  assert.equal(persistSecondResult.code, 0, persistSecondResult.stderr);
+  const persistedSecond = parseJsonOutput(persistSecondResult.stdout);
+  assert.equal(persistedSecond.receipt.action, "planned");
+  const secondReleaseId = persistedSecond.releaseId;
+
+  const activateSecondResult = await runCli(tempRoot, [
+    "release",
+    "activate",
+    "lifeline-pilot",
+    secondReleaseId,
+  ]);
+  assert.equal(activateSecondResult.code, 0, activateSecondResult.stderr);
+  const activatedSecond = parseJsonOutput(activateSecondResult.stdout);
+  assert.equal(activatedSecond.ok, true);
+  assert.equal(activatedSecond.current.releaseId, secondReleaseId);
+  assert.equal(activatedSecond.previous.releaseId, firstReleaseId);
+  assert.equal(
+    activatedSecond.receipt.lineage.promotedFromReleaseId,
+    firstReleaseId,
+  );
+
+  const rollbackResult = await runCli(tempRoot, [
+    "release",
+    "rollback",
+    "lifeline-pilot",
+  ]);
+  assert.equal(rollbackResult.code, 0, rollbackResult.stderr);
+  const rolledBack = parseJsonOutput(rollbackResult.stdout);
+  assert.equal(rolledBack.ok, true);
+  assert.equal(rolledBack.current.releaseId, firstReleaseId);
+  assert.equal(rolledBack.previous.releaseId, secondReleaseId);
+  assert.equal(rolledBack.receipt.action, "rollback");
+  assert.equal(rolledBack.receipt.status, "succeeded");
+
+  console.log("Wave 1 release CLI deterministic verification passed.");
+} finally {
+  // Leave no repo-local runtime residue behind after the deterministic run.
+  await import("node:fs/promises").then(({ rm }) =>
+    rm(tempRoot, { recursive: true, force: true }),
+  );
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { runDoctorCommand } from "./commands/doctor.js";
 import { runExecuteCommand } from "./commands/execute.js";
 import { runLogsCommand } from "./commands/logs.js";
 import { runProofPassCommand } from "./commands/proof-pass.js";
+import { runReleaseCommand } from "./commands/release.js";
 import { runResolveCommand } from "./commands/resolve.js";
 import { runRestartCommand } from "./commands/restart.js";
 import { runRestoreCommand } from "./commands/restore.js";
@@ -16,7 +17,7 @@ import { runSupervisor } from "./core/supervisor.js";
 
 function printUsage(): void {
   console.log(
-    "Lifeline v1 + Wave 2 startup and execution contracts\n\nUsage:\n  lifeline doctor\n  lifeline validate <manifest-path> [--playbook-path <path>]\n  lifeline resolve <manifest-path> [--playbook-path <path>]\n  lifeline up <manifest-path> [--playbook-path <path>]\n  lifeline down <app-name>\n  lifeline status <app-name> [--proof|--proof-text] [--proof-gate]\n  lifeline logs <app-name> [line-count]\n  lifeline restart <app-name> [--playbook-path <path>]\n  lifeline restore\n  lifeline startup <enable|disable|status> [--dry-run]\n  lifeline execute <request-path> --capability-profile <path> --approval-receipt <path> [--receipt-dir <path>]\n  lifeline proof-pass <proof-summary-path> --source-repo <id> --tranche <id> [--receipt-dir <path>]",
+    "Lifeline v1 + Wave 2 startup and execution contracts\n\nUsage:\n  lifeline doctor\n  lifeline validate <manifest-path> [--playbook-path <path>]\n  lifeline resolve <manifest-path> [--playbook-path <path>]\n  lifeline up <manifest-path> [--playbook-path <path>]\n  lifeline down <app-name>\n  lifeline status <app-name> [--proof|--proof-text] [--proof-gate]\n  lifeline logs <app-name> [line-count]\n  lifeline restart <app-name> [--playbook-path <path>]\n  lifeline restore\n  lifeline startup <enable|disable|status> [--dry-run]\n  lifeline release <plan|persist> <deploy-manifest>\n  lifeline release activate <app-name> <release-id>\n  lifeline release rollback <app-name>\n  lifeline execute <request-path> --capability-profile <path> --approval-receipt <path> [--receipt-dir <path>]\n  lifeline proof-pass <proof-summary-path> --source-repo <id> --tranche <id> [--receipt-dir <path>]",
   );
 }
 
@@ -158,6 +159,8 @@ async function main(argv: string[]): Promise<number> {
       return runRestoreCommand();
     case "startup":
       return runStartupCommand(target, option);
+    case "release":
+      return runReleaseCommand(rest);
     case "execute":
       return runExecuteCommand(rest);
     case "proof-pass":

--- a/src/commands/release.ts
+++ b/src/commands/release.ts
@@ -1,0 +1,165 @@
+import { readFile } from "node:fs/promises";
+
+type ReleaseAction = "plan" | "persist" | "activate" | "rollback";
+
+type Wave1ReleasePlanResult = {
+  validation: {
+    status: string;
+  };
+};
+
+type Wave1ReleaseMutationResult = {
+  ok: boolean;
+};
+
+type Wave1ReleaseModules = {
+  planWave1Release: (
+    manifest: unknown,
+    options?: { rootDir?: string },
+  ) => Wave1ReleasePlanResult & Record<string, unknown>;
+  persistWave1Release: (
+    manifest: unknown,
+    options?: { rootDir?: string },
+  ) => Promise<Wave1ReleasePlanResult & Record<string, unknown>>;
+  activateWave1Release: (
+    rootDir: string,
+    appName: string,
+    releaseId: string,
+  ) => Promise<Wave1ReleaseMutationResult & Record<string, unknown>>;
+  rollbackWave1Release: (
+    rootDir: string,
+    appName: string,
+  ) => Promise<Wave1ReleaseMutationResult & Record<string, unknown>>;
+};
+
+function printReleaseUsage(): void {
+  console.error(
+    "Usage:\n  lifeline release plan <deploy-manifest>\n  lifeline release persist <deploy-manifest>\n  lifeline release activate <app-name> <release-id>\n  lifeline release rollback <app-name>",
+  );
+}
+
+function isReleaseAction(value: string | undefined): value is ReleaseAction {
+  return (
+    value === "plan" ||
+    value === "persist" ||
+    value === "activate" ||
+    value === "rollback"
+  );
+}
+
+async function loadWave1ReleaseModules(): Promise<Wave1ReleaseModules> {
+  const moduleUrl = new URL(
+    "../../control-plane/wave1-release-engine.mjs",
+    import.meta.url,
+  );
+
+  return import(moduleUrl.href) as Promise<Wave1ReleaseModules>;
+}
+
+async function loadDeployManifest(manifestPath: string): Promise<unknown> {
+  let raw: string;
+  try {
+    raw = await readFile(manifestPath, "utf8");
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "unknown read error";
+    throw new Error(`Could not read deploy manifest at ${manifestPath}: ${message}`);
+  }
+
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "unknown parse error";
+    throw new Error(
+      `Could not parse deploy manifest JSON at ${manifestPath}: ${message}`,
+    );
+  }
+}
+
+function printJson(payload: unknown): void {
+  console.log(JSON.stringify(payload, null, 2));
+}
+
+function exitCodeForPlanResult(result: Wave1ReleasePlanResult): number {
+  return result.validation.status === "passed" ? 0 : 1;
+}
+
+function exitCodeForMutationResult(result: Wave1ReleaseMutationResult): number {
+  return result.ok ? 0 : 1;
+}
+
+export async function runReleaseCommand(args: string[]): Promise<number> {
+  try {
+    const [action, ...rest] = args;
+    if (!action) {
+      console.error(
+        "Missing release action. Use one of: plan, persist, activate, rollback.",
+      );
+      printReleaseUsage();
+      return 1;
+    }
+
+    if (!isReleaseAction(action)) {
+      console.error(
+        `Unknown release action: ${action}. Use one of: plan, persist, activate, rollback.`,
+      );
+      printReleaseUsage();
+      return 1;
+    }
+
+    const modules = await loadWave1ReleaseModules();
+    const rootDir = process.cwd();
+
+    if (action === "plan" || action === "persist") {
+      const manifestPath = rest[0];
+      if (!manifestPath) {
+        console.error("Missing deploy manifest path.");
+        printReleaseUsage();
+        return 1;
+      }
+
+      const manifest = await loadDeployManifest(manifestPath);
+      const result =
+        action === "plan"
+          ? modules.planWave1Release(manifest, { rootDir })
+          : await modules.persistWave1Release(manifest, { rootDir });
+
+      printJson(result);
+      return exitCodeForPlanResult(result);
+    }
+
+    if (action === "activate") {
+      const appName = rest[0];
+      const releaseId = rest[1];
+      if (!appName || !releaseId) {
+        console.error("Missing app name or release id.");
+        printReleaseUsage();
+        return 1;
+      }
+
+      const result = await modules.activateWave1Release(
+        rootDir,
+        appName,
+        releaseId,
+      );
+      printJson(result);
+      return exitCodeForMutationResult(result);
+    }
+
+    const appName = rest[0];
+    if (!appName) {
+      console.error("Missing app name.");
+      printReleaseUsage();
+      return 1;
+    }
+
+    const result = await modules.rollbackWave1Release(rootDir, appName);
+    printJson(result);
+    return exitCodeForMutationResult(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    return 1;
+  }
+}


### PR DESCRIPTION
## Summary

- add `lifeline release plan <deploy-manifest>`
- add `lifeline release persist <deploy-manifest>`
- add `lifeline release activate <app-name> <release-id>`
- add `lifeline release rollback <app-name>`
- route the release surface through the existing Wave 1 deploy contract and release engine
- add deterministic release CLI coverage
- update operator-facing docs and command-surface parity coverage

## Verification

- `pnpm run verify`
- `node scripts/test-readme-command-surface-deterministic.mjs`
- `node scripts/test-cli-dispatch-deterministic.mjs`

## Scope note

This is a bounded Lifeline release-CLI surface. It does not add domain automation, TLS automation, preview-host assumptions, hosted control-plane behavior, or Trove-specific special casing.
