### PR TITLE
Lifeline: add release phase hooks

### DIFF
--- a/control-plane/wave1-deploy-contract.mjs
+++ b/control-plane/wave1-deploy-contract.mjs
@@ -7,7 +7,14 @@ export const WAVE1_DRY_RUN_PLAN_VERSION = "atlas.lifeline.deploy-dry-run.v1";
 export const WAVE1_RELEASE_PLAN_VERSION = "atlas.lifeline.release-plan.v1";
 
 export const SUPPORTED_ROLLBACK_STRATEGIES = ["redeploy", "restore"];
-export const SUPPORTED_HOOK_NAMES = ["preDeploy", "postDeploy", "rollback"];
+export const SUPPORTED_HOOK_NAMES = [
+  "preDeploy",
+  "postDeploy",
+  "rollback",
+  "preActivate",
+  "postActivate",
+  "preRollback",
+];
 export const SUPPORTED_SOURCE_ADAPTER_KINDS = [
   "artifactRef",
   "imageRef",
@@ -107,6 +114,9 @@ function validateHooks(hooks, issues) {
     preDeploy: [],
     postDeploy: [],
     rollback: [],
+    preActivate: [],
+    postActivate: [],
+    preRollback: [],
   };
 
   for (const hookName of SUPPORTED_HOOK_NAMES) {

--- a/control-plane/wave1-release-engine.mjs
+++ b/control-plane/wave1-release-engine.mjs
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
 import { access, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 
@@ -133,6 +134,116 @@ function previousPointerPath(rootDir, appName) {
 
 function receiptsDirectory(rootDir, appName) {
   return path.join(appReleaseRoot(rootDir, appName), "receipts");
+}
+
+function getMigrationHookCommands(migrationHooks, hookName) {
+  const hookCommands = migrationHooks?.[hookName];
+  return Array.isArray(hookCommands) ? hookCommands : [];
+}
+
+function executeShellCommand(command, options = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(command, {
+      cwd: options.cwd,
+      env: options.env ?? process.env,
+      shell: true,
+      windowsHide: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout?.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    child.stderr?.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    child.on("error", (error) => {
+      resolve({
+        command,
+        status: "failed",
+        exitCode: 1,
+        signal: undefined,
+        stdout,
+        stderr,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+
+    child.on("close", (exitCode, signal) => {
+      if (exitCode === 0 && signal === null) {
+        resolve({
+          command,
+          status: "succeeded",
+          exitCode: 0,
+          signal: undefined,
+          stdout,
+          stderr,
+        });
+        return;
+      }
+
+      resolve({
+        command,
+        status: "failed",
+        exitCode: typeof exitCode === "number" ? exitCode : 1,
+        signal: signal ?? undefined,
+        stdout,
+        stderr,
+        ...(signal ? { error: `Command terminated by signal ${signal}` } : {}),
+      });
+    });
+  });
+}
+
+async function runReleasePhase(rootDir, phase, hookCommands) {
+  const commands = Array.isArray(hookCommands) ? hookCommands : [];
+  const commandResults = [];
+
+  for (const command of commands) {
+    const result = await executeShellCommand(command, { cwd: rootDir });
+    commandResults.push({
+      command: result.command,
+      status: result.status,
+      exitCode: result.exitCode,
+      ...(result.signal ? { signal: result.signal } : {}),
+    });
+
+    if (result.status !== "succeeded") {
+      return {
+        phase,
+        status: "failed",
+        commands: commandResults,
+      };
+    }
+  }
+
+  return {
+    phase,
+    status: "succeeded",
+    commands: commandResults,
+  };
+}
+
+async function restoreReleasePointers(rootDir, appName, current, previous) {
+  const currentPath = currentPointerPath(rootDir, appName);
+  const previousPath = previousPointerPath(rootDir, appName);
+
+  if (current) {
+    await writePointer(currentPath, current);
+  } else {
+    await clearPointer(currentPath);
+  }
+
+  if (previous) {
+    await writePointer(previousPath, previous);
+  } else {
+    await clearPointer(previousPath);
+  }
 }
 
 function deriveReceiptId(payload) {
@@ -343,13 +454,62 @@ export async function activateWave1Release(
   const { metadata } = await loadReleaseMetadata(resolvedRoot, appName, releaseId);
   const current = await readPointer(layout.currentPointerPath);
   const previous = await readPointer(layout.previousPointerPath);
+  const receiptAt = options.receiptAt ?? metadata.createdAt;
+  const preActivate = await runReleasePhase(
+    resolvedRoot,
+    "preActivate",
+    getMigrationHookCommands(metadata.migrationHooks, "preActivate"),
+  );
+
+  if (preActivate.status !== "succeeded") {
+    const failedReceipt = await writeReceipt(resolvedRoot, appName, {
+      action: "activate",
+      status: "failed",
+      appName,
+      releaseId,
+      previousReleaseId: current?.releaseId,
+      createdAt: receiptAt,
+      releaseDirectory: normalizeRelativePath(resolvedRoot, layout.releaseDirectory),
+      releaseMetadataPath: normalizeRelativePath(
+        resolvedRoot,
+        layout.releaseMetadataPath,
+      ),
+      currentPointerPath: normalizeRelativePath(
+        resolvedRoot,
+        layout.currentPointerPath,
+      ),
+      previousPointerPath: normalizeRelativePath(
+        resolvedRoot,
+        layout.previousPointerPath,
+      ),
+      releaseTarget: metadata.releaseTarget,
+      rollbackTarget: metadata.rollbackTarget,
+      phaseEvidence: {
+        preActivate,
+      },
+      failedPhase: "preActivate",
+      preservedCurrentReleaseId: current?.releaseId,
+      preservedPreviousReleaseId: previous?.releaseId,
+    });
+
+    return {
+      ok: false,
+      phase: "preActivate",
+      current,
+      previous,
+      receipt: {
+        ...failedReceipt.receipt,
+        receiptPath: normalizeRelativePath(resolvedRoot, failedReceipt.receiptPath),
+      },
+    };
+  }
+
   const health =
     (await options.checkHealth?.({
       metadata,
       current,
       previous,
     })) ?? { ok: true, status: 200 };
-  const receiptAt = options.receiptAt ?? metadata.createdAt;
 
   if (!health.ok) {
     const failedReceipt = await writeReceipt(resolvedRoot, appName, {
@@ -375,12 +535,17 @@ export async function activateWave1Release(
       releaseTarget: metadata.releaseTarget,
       rollbackTarget: metadata.rollbackTarget,
       health,
+      phaseEvidence: {
+        preActivate,
+      },
+      failedPhase: "healthcheck",
       preservedCurrentReleaseId: current?.releaseId,
       preservedPreviousReleaseId: previous?.releaseId,
     });
 
     return {
       ok: false,
+      phase: "healthcheck",
       health,
       current,
       previous,
@@ -415,6 +580,61 @@ export async function activateWave1Release(
     await clearPointer(layout.previousPointerPath);
   }
 
+  const postActivate = await runReleasePhase(
+    resolvedRoot,
+    "postActivate",
+    getMigrationHookCommands(metadata.migrationHooks, "postActivate"),
+  );
+
+  if (postActivate.status !== "succeeded") {
+    await restoreReleasePointers(resolvedRoot, appName, current, previous);
+
+    const failedReceipt = await writeReceipt(resolvedRoot, appName, {
+      action: "activate",
+      status: "failed",
+      appName,
+      releaseId,
+      previousReleaseId: current?.releaseId,
+      createdAt: receiptAt,
+      releaseDirectory: normalizeRelativePath(resolvedRoot, layout.releaseDirectory),
+      releaseMetadataPath: normalizeRelativePath(
+        resolvedRoot,
+        layout.releaseMetadataPath,
+      ),
+      currentPointerPath: normalizeRelativePath(
+        resolvedRoot,
+        layout.currentPointerPath,
+      ),
+      previousPointerPath: normalizeRelativePath(
+        resolvedRoot,
+        layout.previousPointerPath,
+      ),
+      releaseTarget: metadata.releaseTarget,
+      rollbackTarget: metadata.rollbackTarget,
+      health,
+      phaseEvidence: {
+        preActivate,
+        postActivate,
+      },
+      failedPhase: "postActivate",
+      preservedCurrentReleaseId: current?.releaseId,
+      preservedPreviousReleaseId: previous?.releaseId,
+      revertedPointers: true,
+    });
+
+    return {
+      ok: false,
+      phase: "postActivate",
+      health,
+      current,
+      previous,
+      receipt: {
+        ...failedReceipt.receipt,
+        receiptPath: normalizeRelativePath(resolvedRoot, failedReceipt.receiptPath),
+      },
+    };
+  }
+
   const activationReceipt = await writeReceipt(resolvedRoot, appName, {
     action: "activate",
     status: "succeeded",
@@ -438,6 +658,10 @@ export async function activateWave1Release(
     releaseTarget: metadata.releaseTarget,
     rollbackTarget: metadata.rollbackTarget,
     health,
+    phaseEvidence: {
+      preActivate,
+      postActivate,
+    },
     lineage: {
       promotedFromReleaseId: current?.releaseId,
       promotedToReleaseId: releaseId,
@@ -477,6 +701,58 @@ export async function rollbackWave1Release(rootDir, appName, options = {}) {
     appName,
     previous.releaseId,
   );
+  const preRollback = await runReleasePhase(
+    resolvedRoot,
+    "preRollback",
+    getMigrationHookCommands(metadata.migrationHooks, "preRollback"),
+  );
+
+  if (preRollback.status !== "succeeded") {
+    const failedReceipt = await writeReceipt(resolvedRoot, appName, {
+      action: "rollback",
+      status: "failed",
+      appName,
+      releaseId: previous.releaseId,
+      previousReleaseId: current.releaseId,
+      createdAt: options.receiptAt ?? metadata.createdAt,
+      releaseDirectory: normalizeRelativePath(
+        resolvedRoot,
+        targetLayout.releaseDirectory,
+      ),
+      releaseMetadataPath: normalizeRelativePath(
+        resolvedRoot,
+        targetLayout.releaseMetadataPath,
+      ),
+      currentPointerPath: normalizeRelativePath(
+        resolvedRoot,
+        targetLayout.currentPointerPath,
+      ),
+      previousPointerPath: normalizeRelativePath(
+        resolvedRoot,
+        targetLayout.previousPointerPath,
+      ),
+      releaseTarget: metadata.releaseTarget,
+      rollbackTarget: metadata.rollbackTarget,
+      phaseEvidence: {
+        preRollback,
+      },
+      failedPhase: "preRollback",
+      preservedCurrentReleaseId: current.releaseId,
+      preservedPreviousReleaseId: previous.releaseId,
+    });
+
+    return {
+      ok: false,
+      phase: "preRollback",
+      current,
+      previous,
+      receipt: {
+        ...failedReceipt.receipt,
+        receiptPath: normalizeRelativePath(resolvedRoot, failedReceipt.receiptPath),
+      },
+    };
+  }
+
   const health =
     (await options.checkHealth?.({
       metadata,
@@ -512,12 +788,17 @@ export async function rollbackWave1Release(rootDir, appName, options = {}) {
       releaseTarget: metadata.releaseTarget,
       rollbackTarget: metadata.rollbackTarget,
       health,
+      phaseEvidence: {
+        preRollback,
+      },
+      failedPhase: "healthcheck",
       preservedCurrentReleaseId: current.releaseId,
       preservedPreviousReleaseId: previous.releaseId,
     });
 
     return {
       ok: false,
+      phase: "healthcheck",
       health,
       current,
       previous,
@@ -572,6 +853,9 @@ export async function rollbackWave1Release(rootDir, appName, options = {}) {
     releaseTarget: metadata.releaseTarget,
     rollbackTarget: metadata.rollbackTarget,
     health,
+    phaseEvidence: {
+      preRollback,
+    },
     lineage: {
       promotedFromReleaseId: current.releaseId,
       promotedToReleaseId: previous.releaseId,

--- a/docs/contracts/wave1-deploy-contract.md
+++ b/docs/contracts/wave1-deploy-contract.md
@@ -22,6 +22,9 @@ The deploy manifest is a JSON object with:
 - `migrationHooks.preDeploy`
 - `migrationHooks.postDeploy`
 - `migrationHooks.rollback`
+- `migrationHooks.preActivate`
+- `migrationHooks.postActivate`
+- `migrationHooks.preRollback`
 - `rollbackTarget.releaseId`
 - `rollbackTarget.artifactRef`
 - `rollbackTarget.strategy`
@@ -47,6 +50,8 @@ When the input arrived as `imageRef` or `repo` + `branch`, Lifeline preserves th
 
 The persisted metadata stays JSON only, with no hosted control-plane state embedded.
 
+Phase hook arrays stay as command strings. Lifeline does not invent a new hook DSL for Wave 1.
+
 ## Dry-run path
 
 The dry-run path is a pure planning path:
@@ -69,9 +74,16 @@ Wave 1 release execution is local-first and single-host:
 - activation is health-gated before the current pointer advances
 - failed health gates preserve the existing current and previous release pointers
 - rollback promotes the previous known-good release back to current
+- activation runs `preActivate` before the health gate and before any pointer mutation
+- activation runs `postActivate` only after a provisional activation has succeeded
+- rollback runs `preRollback` before the rollback health gate and before any pointer mutation
+- failed pre-activation or pre-rollback work preserves the existing pointers
+- failed post-activation work restores the original pointers before the failure receipt is written
 - plan, activation, failed activation, and rollback each emit a receipt under `.lifeline/releases/<app>/receipts/`
 
 This keeps the durable release target explicit without widening Lifeline into preview URLs, hosted control-plane behavior, domains, or TLS management.
+
+Phase evidence is recorded in the release receipt so operators can see which commands ran and which phase blocked the transition.
 
 ## Schema files
 

--- a/docs/ops/lifeline-operator-surface.md
+++ b/docs/ops/lifeline-operator-surface.md
@@ -70,8 +70,9 @@ Useful signals:
 
 - `lifeline release plan <deploy-manifest>` previews the deterministic release id and local `.lifeline/releases/<app>/...` layout without writing state.
 - `lifeline release persist <deploy-manifest>` writes immutable release metadata and a planned receipt.
-- `lifeline release activate <app-name> <release-id>` advances the current release pointer to one persisted release id.
-- `lifeline release rollback <app-name>` promotes the previous known-good release back to current.
+- `lifeline release activate <app-name> <release-id>` runs `preActivate`, performs the health gate, advances the current release pointer, and then runs `postActivate`.
+- `lifeline release rollback <app-name>` runs `preRollback`, performs the rollback health gate, and then promotes the previous known-good release back to current.
+- Release phase receipts record the phase evidence that ran, and failed phase work preserves the existing pointers.
 - This lane is local-first and bounded. It does not imply preview hosts, domain automation, TLS automation, or hosted control-plane behavior.
 
 ## Smoke-check path

--- a/schemas/wave1-deploy-contract.schema.json
+++ b/schemas/wave1-deploy-contract.schema.json
@@ -94,6 +94,27 @@
             "type": "string",
             "minLength": 1
           }
+        },
+        "preActivate": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "postActivate": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "preRollback": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         }
       },
       "additionalProperties": false

--- a/schemas/wave1-release-metadata.schema.json
+++ b/schemas/wave1-release-metadata.schema.json
@@ -92,6 +92,27 @@
             "type": "string",
             "minLength": 1
           }
+        },
+        "preActivate": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "postActivate": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "preRollback": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         }
       },
       "additionalProperties": false

--- a/scripts/test-wave1-release-cli-deterministic.mjs
+++ b/scripts/test-wave1-release-cli-deterministic.mjs
@@ -22,6 +22,30 @@ function parseJsonOutput(output) {
   return JSON.parse(output);
 }
 
+function quoteShellArg(value) {
+  return `"${String(value).replace(/"/g, '\\"')}"`;
+}
+
+function buildHookCommand(scriptPath, phase, mode, logPath) {
+  return [
+    process.execPath,
+    scriptPath,
+    phase,
+    mode,
+    logPath,
+  ]
+    .map(quoteShellArg)
+    .join(" ");
+}
+
+async function readLogLines(filePath) {
+  const contents = await readFile(filePath, "utf8");
+  return contents
+    .trim()
+    .split(/\r?\n/)
+    .filter((line) => line.length > 0);
+}
+
 async function runCli(cwd, args) {
   try {
     const { stdout, stderr } = await execFileAsync(process.execPath, [cliPath, ...args], {
@@ -44,6 +68,41 @@ await ensureBuilt();
 const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lifeline-release-cli-"));
 
 try {
+  const hookLogPath = path.join(tempRoot, "hook-log.txt");
+  const hookRunnerPath = path.join(tempRoot, "hook-runner.mjs");
+  await writeFile(
+    hookRunnerPath,
+    [
+      "import { appendFile } from 'node:fs/promises';",
+      "const [phase, mode, logPath] = process.argv.slice(2);",
+      "await appendFile(logPath, `${phase}\\n`, 'utf8');",
+      "if (mode === 'fail') {",
+      "  process.exit(1);",
+      "}",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const manifestSource = JSON.parse(await readFile(fixtureManifestPath, "utf8"));
+  manifestSource.migrationHooks = {
+    ...manifestSource.migrationHooks,
+    preActivate: [
+      buildHookCommand(hookRunnerPath, "preActivate", "success", hookLogPath),
+    ],
+    postActivate: [
+      buildHookCommand(hookRunnerPath, "postActivate", "success", hookLogPath),
+    ],
+    preRollback: [
+      buildHookCommand(hookRunnerPath, "preRollback", "success", hookLogPath),
+    ],
+  };
+  const hookedManifestPath = path.join(tempRoot, "wave1-pilot-release.manifest.json");
+  await writeFile(
+    hookedManifestPath,
+    `${JSON.stringify(manifestSource, null, 2)}\n`,
+    "utf8",
+  );
+
   const missingAction = await runCli(tempRoot, ["release"]);
   assert.equal(missingAction.code, 1);
   assert.match(
@@ -58,7 +117,7 @@ try {
   const planResult = await runCli(tempRoot, [
     "release",
     "plan",
-    fixtureManifestPath,
+    hookedManifestPath,
   ]);
   assert.equal(planResult.code, 0, planResult.stderr);
   const planned = parseJsonOutput(planResult.stdout);
@@ -70,7 +129,7 @@ try {
   const persistedResult = await runCli(tempRoot, [
     "release",
     "persist",
-    fixtureManifestPath,
+    hookedManifestPath,
   ]);
   assert.equal(persistedResult.code, 0, persistedResult.stderr);
   const persisted = parseJsonOutput(persistedResult.stdout);
@@ -102,9 +161,12 @@ try {
   assert.equal(activatedFirst.current.releaseId, firstReleaseId);
   assert.equal(activatedFirst.receipt.action, "activate");
   assert.equal(activatedFirst.receipt.status, "succeeded");
+  assert.equal(activatedFirst.receipt.phaseEvidence.preActivate.status, "succeeded");
+  assert.equal(activatedFirst.receipt.phaseEvidence.postActivate.status, "succeeded");
+  assert.deepEqual(await readLogLines(hookLogPath), ["preActivate", "postActivate"]);
 
   const secondManifestPath = path.join(tempRoot, "wave1-pilot-deploy-2.manifest.json");
-  const secondManifest = JSON.parse(await readFile(fixtureManifestPath, "utf8"));
+  const secondManifest = JSON.parse(await readFile(hookedManifestPath, "utf8"));
   secondManifest.imageRef =
     "ghcr.io/fawxzzy/lifeline-pilot@sha256:22223333444455556666777788889999aaaabbbbccccddddeeeeffff00001111";
   secondManifest.rollbackTarget.releaseId = firstReleaseId;
@@ -137,6 +199,14 @@ try {
     activatedSecond.receipt.lineage.promotedFromReleaseId,
     firstReleaseId,
   );
+  assert.equal(activatedSecond.receipt.phaseEvidence.preActivate.status, "succeeded");
+  assert.equal(activatedSecond.receipt.phaseEvidence.postActivate.status, "succeeded");
+  assert.deepEqual(await readLogLines(hookLogPath), [
+    "preActivate",
+    "postActivate",
+    "preActivate",
+    "postActivate",
+  ]);
 
   const rollbackResult = await runCli(tempRoot, [
     "release",
@@ -150,6 +220,14 @@ try {
   assert.equal(rolledBack.previous.releaseId, secondReleaseId);
   assert.equal(rolledBack.receipt.action, "rollback");
   assert.equal(rolledBack.receipt.status, "succeeded");
+  assert.equal(rolledBack.receipt.phaseEvidence.preRollback.status, "succeeded");
+  assert.deepEqual(await readLogLines(hookLogPath), [
+    "preActivate",
+    "postActivate",
+    "preActivate",
+    "postActivate",
+    "preRollback",
+  ]);
 
   console.log("Wave 1 release CLI deterministic verification passed.");
 } finally {

--- a/scripts/test-wave1-release-mechanics-deterministic.mjs
+++ b/scripts/test-wave1-release-mechanics-deterministic.mjs
@@ -2,6 +2,7 @@ import { strict as assert } from "node:assert";
 import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import process from "node:process";
 
 import {
   buildWave1ReleaseMetadata,
@@ -19,6 +20,7 @@ function createManifest({
   artifactRef,
   rollbackReleaseId,
   rollbackArtifactRef,
+  migrationHooks,
 }) {
   return {
     contractVersion: "atlas.lifeline.deploy-contract.v1",
@@ -34,6 +36,7 @@ function createManifest({
       preDeploy: ["pnpm verify"],
       postDeploy: ["pnpm smoke:release"],
       rollback: ["pnpm rollback:release"],
+      ...(migrationHooks ?? {}),
     },
     rollbackTarget: {
       releaseId: rollbackReleaseId,
@@ -54,6 +57,45 @@ async function pathExists(filePath) {
   } catch {
     return false;
   }
+}
+
+function quoteShellArg(value) {
+  return `"${String(value).replace(/"/g, '\\"')}"`;
+}
+
+function buildHookCommand(scriptPath, phase, mode, logPath) {
+  return [
+    process.execPath,
+    scriptPath,
+    phase,
+    mode,
+    logPath,
+  ]
+    .map(quoteShellArg)
+    .join(" ");
+}
+
+async function writeHookRunner(scriptPath) {
+  await writeFile(
+    scriptPath,
+    [
+      "import { appendFile } from 'node:fs/promises';",
+      "const [phase, mode, logPath] = process.argv.slice(2);",
+      "await appendFile(logPath, `${phase}\\n`, 'utf8');",
+      "if (mode === 'fail') {",
+      "  process.exit(1);",
+      "}",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+async function readHookLogLines(logPath) {
+  const contents = await readFile(logPath, "utf8");
+  return contents
+    .trim()
+    .split(/\r?\n/)
+    .filter((line) => line.length > 0);
 }
 
 async function writeLegacyReleaseMetadata(rootDir, manifest, options) {
@@ -93,6 +135,33 @@ const tempRoot = await mkdtemp(
 try {
   const appName = "lifeline-pilot";
   const outsidePath = path.join(tempRoot, ".lifeline", "outside");
+  const hookRunnerPath = path.join(tempRoot, "hook-runner.mjs");
+  const hookLogPath = path.join(tempRoot, "hook-log.txt");
+  await writeHookRunner(hookRunnerPath);
+
+  const successHooks = {
+    preActivate: [
+      buildHookCommand(hookRunnerPath, "preActivate", "success", hookLogPath),
+    ],
+    postActivate: [
+      buildHookCommand(hookRunnerPath, "postActivate", "success", hookLogPath),
+    ],
+    preRollback: [
+      buildHookCommand(hookRunnerPath, "preRollback", "success", hookLogPath),
+    ],
+  };
+  const failingPreActivateHooks = {
+    ...successHooks,
+    preActivate: [
+      buildHookCommand(hookRunnerPath, "preActivate", "fail", hookLogPath),
+    ],
+  };
+  const failingPreRollbackHooks = {
+    ...successHooks,
+    preRollback: [
+      buildHookCommand(hookRunnerPath, "preRollback", "fail", hookLogPath),
+    ],
+  };
 
   const releaseA = await persistWave1Release(
     createManifest({
@@ -101,6 +170,7 @@ try {
       rollbackReleaseId: "bootstrap-release",
       rollbackArtifactRef:
         "ghcr.io/fawxzzy/lifeline-pilot@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      migrationHooks: successHooks,
     }),
     {
       rootDir: tempRoot,
@@ -123,13 +193,14 @@ try {
 
   await assert.rejects(
     persistWave1Release(
-      createManifest({
-        appName,
-        artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:1111111111111111111111111111111111111111111111111111111111111111",
-        rollbackReleaseId: "bootstrap-release",
-        rollbackArtifactRef:
-          "ghcr.io/fawxzzy/lifeline-pilot@sha256:0000000000000000000000000000000000000000000000000000000000000000",
-      }),
+    createManifest({
+      appName,
+      artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      rollbackReleaseId: "bootstrap-release",
+      rollbackArtifactRef:
+        "ghcr.io/fawxzzy/lifeline-pilot@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      migrationHooks: successHooks,
+    }),
       {
         rootDir: tempRoot,
         releaseId: "../../outside",
@@ -143,13 +214,14 @@ try {
 
   await assert.rejects(
     persistWave1Release(
-      createManifest({
-        appName,
-        artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:1212121212121212121212121212121212121212121212121212121212121212",
-        rollbackReleaseId: "bootstrap-release",
-        rollbackArtifactRef:
-          "ghcr.io/fawxzzy/lifeline-pilot@sha256:0000000000000000000000000000000000000000000000000000000000000000",
-      }),
+    createManifest({
+      appName,
+      artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:1212121212121212121212121212121212121212121212121212121212121212",
+      rollbackReleaseId: "bootstrap-release",
+      rollbackArtifactRef:
+        "ghcr.io/fawxzzy/lifeline-pilot@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      migrationHooks: successHooks,
+    }),
       {
         rootDir: tempRoot,
         releaseId: "..\\..\\outside",
@@ -173,6 +245,12 @@ try {
   assert.equal(activationA.ok, true);
   assert.equal(activationA.current.releaseId, releaseA.releaseId);
   assert.equal(activationA.previous, undefined);
+  assert.equal(activationA.receipt.phaseEvidence.preActivate.status, "succeeded");
+  assert.equal(activationA.receipt.phaseEvidence.postActivate.status, "succeeded");
+  assert.deepEqual(await readHookLogLines(hookLogPath), [
+    "preActivate",
+    "postActivate",
+  ]);
 
   const releaseB = await persistWave1Release(
     createManifest({
@@ -180,6 +258,7 @@ try {
       artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
       rollbackReleaseId: releaseA.releaseId,
       rollbackArtifactRef: releaseA.releaseMetadata.artifactRef,
+      migrationHooks: successHooks,
     }),
     {
       rootDir: tempRoot,
@@ -200,6 +279,8 @@ try {
   assert.equal(activationB.ok, true);
   assert.equal(activationB.current.releaseId, releaseB.releaseId);
   assert.equal(activationB.previous.releaseId, releaseA.releaseId);
+  assert.equal(activationB.receipt.phaseEvidence.preActivate.status, "succeeded");
+  assert.equal(activationB.receipt.phaseEvidence.postActivate.status, "succeeded");
   assert.equal(
     activationB.receipt.lineage.promotedFromReleaseId,
     releaseA.releaseId,
@@ -209,6 +290,12 @@ try {
     releaseB.releaseId,
   );
   assert.equal(activationB.receipt.health.status, 200);
+  assert.deepEqual(await readHookLogLines(hookLogPath), [
+    "preActivate",
+    "postActivate",
+    "preActivate",
+    "postActivate",
+  ]);
 
   const stateAfterSuccess = await readWave1ReleaseState(tempRoot, appName);
   assert.equal(stateAfterSuccess.current.releaseId, releaseB.releaseId);
@@ -220,6 +307,7 @@ try {
       artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
       rollbackReleaseId: releaseB.releaseId,
       rollbackArtifactRef: releaseB.releaseMetadata.artifactRef,
+      migrationHooks: failingPreActivateHooks,
     }),
     {
       rootDir: tempRoot,
@@ -245,10 +333,19 @@ try {
   assert.equal(failedActivation.current.releaseId, releaseB.releaseId);
   assert.equal(failedActivation.previous.releaseId, releaseA.releaseId);
   assert.equal(failedActivation.receipt.status, "failed");
+  assert.equal(failedActivation.receipt.failedPhase, "preActivate");
+  assert.equal(failedActivation.receipt.phaseEvidence.preActivate.status, "failed");
   assert.equal(
     failedActivation.receipt.preservedCurrentReleaseId,
     releaseB.releaseId,
   );
+  assert.deepEqual(await readHookLogLines(hookLogPath), [
+    "preActivate",
+    "postActivate",
+    "preActivate",
+    "postActivate",
+    "preActivate",
+  ]);
 
   const stateAfterFailedActivation = await readWave1ReleaseState(tempRoot, appName);
   assert.equal(stateAfterFailedActivation.current.releaseId, releaseB.releaseId);
@@ -264,6 +361,15 @@ try {
   assert.equal(rollbackResult.receipt.action, "rollback");
   assert.equal(rollbackResult.receipt.status, "succeeded");
   assert.equal(rollbackResult.receipt.previousReleaseId, releaseB.releaseId);
+  assert.equal(rollbackResult.receipt.phaseEvidence.preRollback.status, "succeeded");
+  assert.deepEqual(await readHookLogLines(hookLogPath), [
+    "preActivate",
+    "postActivate",
+    "preActivate",
+    "postActivate",
+    "preActivate",
+    "preRollback",
+  ]);
 
   const finalState = await readWave1ReleaseState(tempRoot, appName);
   assert.equal(finalState.current.releaseId, releaseA.releaseId);
@@ -298,6 +404,7 @@ try {
       artifactRef: legacyArtifactRef,
       rollbackReleaseId: releaseA.releaseId,
       rollbackArtifactRef: releaseA.releaseMetadata.artifactRef,
+      migrationHooks: successHooks,
     }),
     {
       releaseId: legacyReleaseId,
@@ -329,6 +436,7 @@ try {
       artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       rollbackReleaseId: legacyReleaseId,
       rollbackArtifactRef: legacyArtifactRef,
+      migrationHooks: successHooks,
     }),
     {
       rootDir: tempRoot,
@@ -361,6 +469,98 @@ try {
     releaseId: legacyMetadata.releaseId,
     artifactRef: legacyMetadata.artifactRef,
   });
+
+  const rollbackBlockerRelease = await persistWave1Release(
+    createManifest({
+      appName,
+      artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      rollbackReleaseId: legacyReleaseId,
+      rollbackArtifactRef: legacyArtifactRef,
+      migrationHooks: failingPreRollbackHooks,
+    }),
+    {
+      rootDir: tempRoot,
+      releaseId: "release-20260425-0005",
+      createdAt: "2026-04-25T18:55:00.000Z",
+      receiptAt: "2026-04-25T18:55:00.000Z",
+    },
+  );
+  const rollbackBlockerActivation = await activateWave1Release(
+    tempRoot,
+    appName,
+    rollbackBlockerRelease.releaseId,
+    {
+      receiptAt: "2026-04-25T18:56:00.000Z",
+      checkHealth: async () => ({ ok: true, status: 200 }),
+    },
+  );
+  assert.equal(rollbackBlockerActivation.ok, true);
+  assert.equal(rollbackBlockerActivation.current.releaseId, rollbackBlockerRelease.releaseId);
+  assert.equal(rollbackBlockerActivation.previous.releaseId, legacyReleaseId);
+
+  const rollbackTargetRelease = await persistWave1Release(
+    createManifest({
+      appName,
+      artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:abababababababababababababababababababababababababababababababab",
+      rollbackReleaseId: rollbackBlockerRelease.releaseId,
+      rollbackArtifactRef: rollbackBlockerRelease.releaseMetadata.artifactRef,
+      migrationHooks: successHooks,
+    }),
+    {
+      rootDir: tempRoot,
+      releaseId: "release-20260425-0006",
+      createdAt: "2026-04-25T18:57:00.000Z",
+      receiptAt: "2026-04-25T18:57:00.000Z",
+    },
+  );
+  const rollbackTargetActivation = await activateWave1Release(
+    tempRoot,
+    appName,
+    rollbackTargetRelease.releaseId,
+    {
+      receiptAt: "2026-04-25T18:58:00.000Z",
+      checkHealth: async () => ({ ok: true, status: 200 }),
+    },
+  );
+  assert.equal(rollbackTargetActivation.ok, true);
+  assert.equal(rollbackTargetActivation.current.releaseId, rollbackTargetRelease.releaseId);
+  assert.equal(rollbackTargetActivation.previous.releaseId, rollbackBlockerRelease.releaseId);
+
+  const blockedRollback = await rollbackWave1Release(tempRoot, appName, {
+    receiptAt: "2026-04-25T18:59:00.000Z",
+    checkHealth: async () => ({ ok: true, status: 200 }),
+  });
+  assert.equal(blockedRollback.ok, false);
+  assert.equal(blockedRollback.current.releaseId, rollbackTargetRelease.releaseId);
+  assert.equal(blockedRollback.previous.releaseId, rollbackBlockerRelease.releaseId);
+  assert.equal(blockedRollback.receipt.failedPhase, "preRollback");
+  assert.equal(blockedRollback.receipt.phaseEvidence.preRollback.status, "failed");
+  assert.equal(
+    blockedRollback.receipt.preservedCurrentReleaseId,
+    rollbackTargetRelease.releaseId,
+  );
+  assert.equal(
+    blockedRollback.receipt.preservedPreviousReleaseId,
+    rollbackBlockerRelease.releaseId,
+  );
+  assert.deepEqual(await readHookLogLines(hookLogPath), [
+    "preActivate",
+    "postActivate",
+    "preActivate",
+    "postActivate",
+    "preActivate",
+    "preRollback",
+    "preActivate",
+    "postActivate",
+    "preActivate",
+    "postActivate",
+    "preRollback",
+    "preActivate",
+    "postActivate",
+    "preActivate",
+    "postActivate",
+    "preRollback",
+  ]);
 
   console.log("Wave 1 release mechanics deterministic verification passed.");
 } finally {


### PR DESCRIPTION
## Summary

- add release phase hook support for `preActivate`, `postActivate`, and `preRollback`
- run `preActivate` before release pointer mutation
- run `postActivate` only after provisional activation succeeds
- run `preRollback` before rollback pointer mutation
- preserve current/previous pointers on failed `preActivate` and `preRollback`
- restore original pointers on failed `postActivate`
- include phase evidence in release receipts

## Verification

- `pnpm run verify`
- `node scripts/test-wave1-release-cli-deterministic.mjs`
- `node scripts/test-cli-dispatch-deterministic.mjs`

## Scope note

This is release correctness only. It does not add preview hosting, domain automation, TLS automation, hosted control-plane behavior, or Trove-specific special casing.