### PR TITLE
Lifeline: harden release app path segment

### DIFF
--- a/control-plane/wave1-release-engine.mjs
+++ b/control-plane/wave1-release-engine.mjs
@@ -51,8 +51,32 @@ function releaseRoot(rootDir) {
   return path.join(rootDir, ".lifeline", "releases");
 }
 
+function validateReleaseAppName(appName) {
+  if (typeof appName !== "string" || appName.trim().length === 0) {
+    throw new Error("App name must be a non-empty string.");
+  }
+
+  if (path.isAbsolute(appName)) {
+    throw new Error(`Invalid appName "${appName}": absolute paths are not allowed.`);
+  }
+
+  if (appName.includes("/") || appName.includes("\\")) {
+    throw new Error(
+      `Invalid appName "${appName}": path separators are not allowed.`,
+    );
+  }
+
+  if (appName === "." || appName === "..") {
+    throw new Error(
+      `Invalid appName "${appName}": dot-segment values are not allowed.`,
+    );
+  }
+
+  return appName;
+}
+
 function appReleaseRoot(rootDir, appName) {
-  return path.join(releaseRoot(rootDir), appName);
+  return path.join(releaseRoot(rootDir), validateReleaseAppName(appName));
 }
 
 function hasPathEscape(relativePath) {

--- a/docs/contracts/wave1-deploy-contract.md
+++ b/docs/contracts/wave1-deploy-contract.md
@@ -71,6 +71,7 @@ Wave 1 release execution is local-first and single-host:
 - each release is persisted once at `.lifeline/releases/<app>/<releaseId>/metadata.json`
 - release directories are immutable after the metadata lands
 - mutable activation state lives only in `.lifeline/releases/<app>/current.json` and `previous.json`
+- `<app>` is a single filesystem path segment derived from `appName`, so absolute values, separator-bearing values, and `.` or `..` are rejected before any release path is built
 - activation is health-gated before the current pointer advances
 - failed health gates preserve the existing current and previous release pointers
 - rollback promotes the previous known-good release back to current

--- a/scripts/test-wave1-release-mechanics-deterministic.mjs
+++ b/scripts/test-wave1-release-mechanics-deterministic.mjs
@@ -135,6 +135,7 @@ const tempRoot = await mkdtemp(
 try {
   const appName = "lifeline-pilot";
   const outsidePath = path.join(tempRoot, ".lifeline", "outside");
+  const escapedAppPath = path.join(tempRoot, ".lifeline", "escaped-app");
   const hookRunnerPath = path.join(tempRoot, "hook-runner.mjs");
   const hookLogPath = path.join(tempRoot, "hook-log.txt");
   await writeHookRunner(hookRunnerPath);
@@ -211,6 +212,48 @@ try {
     /Invalid releaseId "\.\.\/\.\.\/outside": path separators are not allowed\./,
   );
   assert.equal(await pathExists(outsidePath), false);
+
+  await assert.rejects(
+    persistWave1Release(
+      createManifest({
+        appName: "../escaped-app",
+        artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:1313131313131313131313131313131313131313131313131313131313131313",
+        rollbackReleaseId: "bootstrap-release",
+        rollbackArtifactRef:
+          "ghcr.io/fawxzzy/lifeline-pilot@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        migrationHooks: successHooks,
+      }),
+      {
+        rootDir: tempRoot,
+        releaseId: "release-20260425-0001-appname-unix",
+        createdAt: "2026-04-25T18:01:30.000Z",
+        receiptAt: "2026-04-25T18:01:30.000Z",
+      },
+    ),
+    /Invalid appName "\.\.\/escaped-app": path separators are not allowed\./,
+  );
+  assert.equal(await pathExists(escapedAppPath), false);
+
+  await assert.rejects(
+    persistWave1Release(
+      createManifest({
+        appName: "..\\escaped-app",
+        artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:1414141414141414141414141414141414141414141414141414141414141414",
+        rollbackReleaseId: "bootstrap-release",
+        rollbackArtifactRef:
+          "ghcr.io/fawxzzy/lifeline-pilot@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        migrationHooks: successHooks,
+      }),
+      {
+        rootDir: tempRoot,
+        releaseId: "release-20260425-0001-appname-win",
+        createdAt: "2026-04-25T18:01:45.000Z",
+        receiptAt: "2026-04-25T18:01:45.000Z",
+      },
+    ),
+    /Invalid appName "\.\.\\escaped-app": path separators are not allowed\./,
+  );
+  assert.equal(await pathExists(escapedAppPath), false);
 
   await assert.rejects(
     persistWave1Release(


### PR DESCRIPTION
## Summary

- validate `appName` before using it as the `.lifeline/releases/<app>/...` filesystem segment
- reject empty, absolute, separator-bearing, `.` and `..` app names at the release-engine boundary
- add deterministic coverage for POSIX and Windows-style app-name path escape attempts
- document the release-state filesystem segment boundary in the Wave 1 deploy contract

## Verification

- `node scripts\test-wave1-release-mechanics-deterministic.mjs`
- `pnpm run verify`

## Scope note

This is release-state path hardening only. It does not add hosted control-plane behavior, preview hosting, domain automation, TLS automation, multi-node orchestration, or Trove-specific special casing.