### PR TITLE
Lifeline: enforce appName contract parity

### DIFF
--- a/control-plane/wave1-deploy-contract.mjs
+++ b/control-plane/wave1-deploy-contract.mjs
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import path from "node:path";
 
 export const WAVE1_DEPLOY_CONTRACT_VERSION = "atlas.lifeline.deploy-contract.v1";
 export const WAVE1_RELEASE_METADATA_VERSION =
@@ -40,6 +41,37 @@ function pushIssue(issues, path, message) {
 
 function normalizeStringList(value) {
   return [...value];
+}
+
+function validateAppName(appName, issues) {
+  if (!isNonEmptyString(appName)) {
+    pushIssue(issues, "appName", "must be a non-empty string");
+    return undefined;
+  }
+
+  if (path.isAbsolute(appName)) {
+    pushIssue(issues, "appName", "must not be an absolute path");
+  }
+
+  if (appName.includes("/") || appName.includes("\\")) {
+    pushIssue(issues, "appName", "must not contain path separators");
+  }
+
+  if (appName === "." || appName === "..") {
+    pushIssue(issues, "appName", "must not equal '.' or '..'");
+  }
+
+  if (
+    path.isAbsolute(appName) ||
+    appName.includes("/") ||
+    appName.includes("\\") ||
+    appName === "." ||
+    appName === ".."
+  ) {
+    return undefined;
+  }
+
+  return appName;
 }
 
 function stableJsonValue(value) {
@@ -411,9 +443,7 @@ export function validateWave1DeployManifest(value) {
     );
   }
 
-  if (!isNonEmptyString(value.appName)) {
-    pushIssue(issues, "appName", "must be a non-empty string");
-  }
+  const appName = validateAppName(value.appName, issues);
 
   const artifactInput = validateArtifactRef(value, issues);
   const route = validateRoute(value.route, issues);
@@ -443,7 +473,7 @@ export function validateWave1DeployManifest(value) {
     issues,
     manifest: {
       contractVersion: WAVE1_DEPLOY_CONTRACT_VERSION,
-      appName: value.appName,
+      appName,
       artifactRef: artifactInput.artifactRef,
       route,
       envRefs: normalizeStringList(envRefs),
@@ -478,9 +508,7 @@ export function validateWave1ReleaseMetadata(value) {
     pushIssue(issues, "releaseId", "must be a non-empty string");
   }
 
-  if (!isNonEmptyString(value.appName)) {
-    pushIssue(issues, "appName", "must be a non-empty string");
-  }
+  const appName = validateAppName(value.appName, issues);
 
   if (!isNonEmptyString(value.artifactRef)) {
     pushIssue(issues, "artifactRef", "must be a non-empty string");
@@ -553,7 +581,7 @@ export function validateWave1ReleaseMetadata(value) {
     metadata: {
       contractVersion: WAVE1_RELEASE_METADATA_VERSION,
       releaseId: value.releaseId,
-      appName: value.appName,
+      appName,
       artifactRef: value.artifactRef,
       route,
       envRefs: normalizeStringList(value.envRefs),

--- a/docs/contracts/wave1-deploy-contract.md
+++ b/docs/contracts/wave1-deploy-contract.md
@@ -30,6 +30,7 @@ The deploy manifest is a JSON object with:
 - `rollbackTarget.strategy`
 
 Canonical validation accepts `artifactRef`, `imageRef`, or a branch-shaped `repo` + `branch` input and normalizes all of them to `artifactRef` for downstream use.
+`appName` is both the logical application identifier and the release-state filesystem segment for `.lifeline/releases/<app>/...`, so contract intake rejects absolute values, separator-bearing values, and `.` or `..` before planning or persistence continues.
 
 ## Release metadata shape
 
@@ -85,6 +86,15 @@ Wave 1 release execution is local-first and single-host:
 This keeps the durable release target explicit without widening Lifeline into preview URLs, hosted control-plane behavior, domains, or TLS management.
 
 Phase evidence is recorded in the release receipt so operators can see which commands ran and which phase blocked the transition.
+
+Rule:
+Filesystem-bound identifiers must fail at contract intake, not only at execution boundaries.
+
+Pattern:
+Validate path-segment safety at both schema/contract boundaries and execution boundaries.
+
+Failure Mode:
+Engine-only validation lets invalid manifests appear valid during planning or external tooling integration, then fail later at release-state mutation time.
 
 ## Schema files
 

--- a/schemas/wave1-deploy-contract.schema.json
+++ b/schemas/wave1-deploy-contract.schema.json
@@ -18,7 +18,23 @@
     },
     "appName": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "allOf": [
+        {
+          "pattern": ".*\\S.*"
+        },
+        {
+          "pattern": "^[^/\\\\]+$"
+        },
+        {
+          "not": {
+            "enum": [
+              ".",
+              ".."
+            ]
+          }
+        }
+      ]
     },
     "repo": {
       "type": "string",

--- a/schemas/wave1-release-metadata.schema.json
+++ b/schemas/wave1-release-metadata.schema.json
@@ -28,7 +28,23 @@
     },
     "appName": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "allOf": [
+        {
+          "pattern": ".*\\S.*"
+        },
+        {
+          "pattern": "^[^/\\\\]+$"
+        },
+        {
+          "not": {
+            "enum": [
+              ".",
+              ".."
+            ]
+          }
+        }
+      ]
     },
     "artifactRef": {
       "type": "string",

--- a/scripts/test-wave1-release-mechanics-deterministic.mjs
+++ b/scripts/test-wave1-release-mechanics-deterministic.mjs
@@ -10,6 +10,7 @@ import {
 } from "../control-plane/wave1-deploy-contract.mjs";
 import {
   activateWave1Release,
+  getWave1ReleaseLayout,
   persistWave1Release,
   readWave1ReleaseState,
   rollbackWave1Release,
@@ -213,43 +214,21 @@ try {
   );
   assert.equal(await pathExists(outsidePath), false);
 
-  await assert.rejects(
-    persistWave1Release(
-      createManifest({
-        appName: "../escaped-app",
-        artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:1313131313131313131313131313131313131313131313131313131313131313",
-        rollbackReleaseId: "bootstrap-release",
-        rollbackArtifactRef:
-          "ghcr.io/fawxzzy/lifeline-pilot@sha256:0000000000000000000000000000000000000000000000000000000000000000",
-        migrationHooks: successHooks,
-      }),
-      {
-        rootDir: tempRoot,
-        releaseId: "release-20260425-0001-appname-unix",
-        createdAt: "2026-04-25T18:01:30.000Z",
-        receiptAt: "2026-04-25T18:01:30.000Z",
-      },
+  assert.throws(
+    () => getWave1ReleaseLayout(
+      tempRoot,
+      "../escaped-app",
+      "release-20260425-0001-appname-unix",
     ),
     /Invalid appName "\.\.\/escaped-app": path separators are not allowed\./,
   );
   assert.equal(await pathExists(escapedAppPath), false);
 
-  await assert.rejects(
-    persistWave1Release(
-      createManifest({
-        appName: "..\\escaped-app",
-        artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:1414141414141414141414141414141414141414141414141414141414141414",
-        rollbackReleaseId: "bootstrap-release",
-        rollbackArtifactRef:
-          "ghcr.io/fawxzzy/lifeline-pilot@sha256:0000000000000000000000000000000000000000000000000000000000000000",
-        migrationHooks: successHooks,
-      }),
-      {
-        rootDir: tempRoot,
-        releaseId: "release-20260425-0001-appname-win",
-        createdAt: "2026-04-25T18:01:45.000Z",
-        receiptAt: "2026-04-25T18:01:45.000Z",
-      },
+  assert.throws(
+    () => getWave1ReleaseLayout(
+      tempRoot,
+      "..\\escaped-app",
+      "release-20260425-0001-appname-win",
     ),
     /Invalid appName "\.\.\\escaped-app": path separators are not allowed\./,
   );

--- a/tests/contracts/test-wave1-deploy-contract-deterministic.mjs
+++ b/tests/contracts/test-wave1-deploy-contract-deterministic.mjs
@@ -200,6 +200,38 @@ assert.deepEqual(invalidManifest.issues, [
   },
 ]);
 
+const invalidAppNames = [
+  { appName: "../escaped-app", expectedMessage: "must not contain path separators" },
+  { appName: "..\\escaped-app", expectedMessage: "must not contain path separators" },
+  { appName: ".", expectedMessage: "must not equal '.' or '..'" },
+  { appName: "..", expectedMessage: "must not equal '.' or '..'" },
+  { appName: "   ", expectedMessage: "must be a non-empty string" },
+];
+
+for (const { appName, expectedMessage } of invalidAppNames) {
+  const invalidAppManifest = validateWave1DeployManifest({
+    ...sampleManifest,
+    appName,
+  });
+  assert(
+    invalidAppManifest.issues.some((issue) => (
+      issue.path === "appName" && issue.message === expectedMessage
+    )),
+    `expected appName validation issue for manifest appName=${JSON.stringify(appName)}, got ${JSON.stringify(invalidAppManifest.issues)}`,
+  );
+
+  const invalidAppMetadata = validateWave1ReleaseMetadata({
+    ...dryRunPlan.releaseMetadata,
+    appName,
+  });
+  assert(
+    invalidAppMetadata.issues.some((issue) => (
+      issue.path === "appName" && issue.message === expectedMessage
+    )),
+    `expected appName validation issue for metadata appName=${JSON.stringify(appName)}, got ${JSON.stringify(invalidAppMetadata.issues)}`,
+  );
+}
+
 const invalidMetadata = validateWave1ReleaseMetadata({
   ...dryRunPlan.releaseMetadata,
   validation: {
@@ -222,13 +254,31 @@ assert.equal(
   deploySchema.properties.rollbackTarget.properties.strategy.enum.join(","),
   "redeploy,restore",
 );
+assert.deepEqual(
+  deploySchema.properties.appName,
+  metadataSchema.properties.appName,
+  "deploy and metadata schemas should enforce the same appName boundary",
+);
+assert.ok(
+  deploySchema.properties.appName.allOf.some((rule) => rule.pattern === ".*\\S.*") &&
+    deploySchema.properties.appName.allOf.some((rule) => rule.pattern === "^[^/\\\\]+$"),
+  "deploy contract schema should reject whitespace-only and separator-bearing app names",
+);
+assert.deepEqual(
+  deploySchema.properties.appName.allOf.find((rule) => rule.not)?.not.enum,
+  [".", ".."],
+  "deploy contract schema should reject '.' and '..' app names",
+);
 assert.ok(
   docs.includes("artifactRef") &&
     docs.includes("imageRef") &&
     docs.includes("repo") &&
     docs.includes("branch") &&
     docs.includes("releaseTarget") &&
-    docs.includes("rollbackTarget.strategy"),
+    docs.includes("rollbackTarget.strategy") &&
+    docs.includes("Filesystem-bound identifiers must fail at contract intake") &&
+    docs.includes("Validate path-segment safety at both schema/contract boundaries and execution boundaries") &&
+    docs.includes("Engine-only validation lets invalid manifests appear valid during planning or external tooling integration"),
   "docs/contracts/wave1-deploy-contract.md should describe the canonical deploy and metadata fields",
 );
 


### PR DESCRIPTION
## Summary

- reject unsafe `appName` values during Wave 1 deploy-contract validation instead of waiting for release-state path construction
- mirror the same `appName` path-segment boundary in both the deploy-contract and release-metadata JSON schemas
- add deterministic coverage for POSIX and Windows-style escape attempts, dot-segment values, and whitespace-only app names
- keep the release-engine guard in place and update the release-mechanics test to exercise that execution-boundary defense directly
- document that `appName` is both a logical app identifier and a release-state filesystem segment

## Verification

- `node tests\contracts\test-wave1-deploy-contract-deterministic.mjs`
- `node scripts\test-wave1-release-mechanics-deterministic.mjs`
- `pnpm run verify`

## Rule

Filesystem-bound identifiers must fail at contract intake, not only at execution boundaries.

## Pattern

Validate path-segment safety at both schema/contract boundaries and execution boundaries.

## Failure Mode

Engine-only validation lets invalid manifests appear valid during planning or external tooling integration, then fail later at release-state mutation time.

## Scope note

This is deploy-contract validation parity only. It does not add hosted control-plane behavior, preview hosting, domain automation, TLS automation, multi-node orchestration, or Trove-specific special casing.