### PR TITLE
Lifeline: validate release receipt contract

### DIFF
--- a/control-plane/wave1-release-engine.mjs
+++ b/control-plane/wave1-release-engine.mjs
@@ -18,6 +18,14 @@ function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function pushIssue(issues, path, message) {
+  issues.push({ path, message });
+}
+
 function stableJsonValue(value) {
   if (Array.isArray(value)) {
     return value.map((entry) => stableJsonValue(entry));
@@ -37,6 +45,502 @@ function stableJsonValue(value) {
 
 function stableJsonStringify(value) {
   return JSON.stringify(stableJsonValue(value), null, 2);
+}
+
+const SUPPORTED_RELEASE_RECEIPT_ACTIONS = ["planned", "activate", "rollback"];
+const SUPPORTED_RELEASE_RECEIPT_STATUSES = ["planned", "succeeded", "failed"];
+const SUPPORTED_RELEASE_PHASE_STATUSES = ["succeeded", "failed"];
+const SUPPORTED_RELEASE_RECEIPT_FAILURE_PHASES = [
+  "preActivate",
+  "healthcheck",
+  "postActivate",
+  "preRollback",
+];
+const SUPPORTED_ROLLBACK_STRATEGIES = ["redeploy", "restore"];
+const SUPPORTED_SOURCE_ADAPTER_KINDS = ["artifactRef", "imageRef", "branch"];
+
+function validateReleaseTarget(receipt, issues) {
+  if (!isRecord(receipt.releaseTarget)) {
+    pushIssue(issues, "releaseTarget", "must be an object");
+    return;
+  }
+
+  if (receipt.releaseTarget.kind !== "single-host-immutable") {
+    pushIssue(issues, "releaseTarget.kind", "must equal single-host-immutable");
+  }
+
+  if (!isNonEmptyString(receipt.releaseTarget.releaseId)) {
+    pushIssue(issues, "releaseTarget.releaseId", "must be a non-empty string");
+  }
+
+  if (!isNonEmptyString(receipt.releaseTarget.artifactRef)) {
+    pushIssue(issues, "releaseTarget.artifactRef", "must be a non-empty string");
+  }
+}
+
+function validateRollbackTarget(receipt, issues) {
+  if (!isRecord(receipt.rollbackTarget)) {
+    pushIssue(issues, "rollbackTarget", "must be an object");
+    return;
+  }
+
+  if (!isNonEmptyString(receipt.rollbackTarget.releaseId)) {
+    pushIssue(issues, "rollbackTarget.releaseId", "must be a non-empty string");
+  }
+
+  if (!isNonEmptyString(receipt.rollbackTarget.artifactRef)) {
+    pushIssue(issues, "rollbackTarget.artifactRef", "must be a non-empty string");
+  }
+
+  if (
+    !isNonEmptyString(receipt.rollbackTarget.strategy) ||
+    !SUPPORTED_ROLLBACK_STRATEGIES.includes(receipt.rollbackTarget.strategy)
+  ) {
+    pushIssue(
+      issues,
+      "rollbackTarget.strategy",
+      `must be one of: ${SUPPORTED_ROLLBACK_STRATEGIES.join(", ")}`,
+    );
+  }
+
+  if (
+    receipt.rollbackTarget.note !== undefined &&
+    !isNonEmptyString(receipt.rollbackTarget.note)
+  ) {
+    pushIssue(issues, "rollbackTarget.note", "must be a non-empty string");
+  }
+}
+
+function validateSourceAdapter(receipt, issues) {
+  if (receipt.sourceAdapter === undefined) {
+    return;
+  }
+
+  if (!isRecord(receipt.sourceAdapter)) {
+    pushIssue(issues, "sourceAdapter", "must be an object");
+    return;
+  }
+
+  if (
+    !isNonEmptyString(receipt.sourceAdapter.kind) ||
+    !SUPPORTED_SOURCE_ADAPTER_KINDS.includes(receipt.sourceAdapter.kind)
+  ) {
+    pushIssue(
+      issues,
+      "sourceAdapter.kind",
+      `must be one of: ${SUPPORTED_SOURCE_ADAPTER_KINDS.join(", ")}`,
+    );
+  }
+
+  if (!isNonEmptyString(receipt.sourceAdapter.canonicalArtifactRef)) {
+    pushIssue(
+      issues,
+      "sourceAdapter.canonicalArtifactRef",
+      "must be a non-empty string",
+    );
+  }
+
+  if (
+    receipt.sourceAdapter.kind === "artifactRef" &&
+    !isNonEmptyString(receipt.sourceAdapter.artifactRef)
+  ) {
+    pushIssue(
+      issues,
+      "sourceAdapter.artifactRef",
+      "must be a non-empty string",
+    );
+  }
+
+  if (
+    receipt.sourceAdapter.kind === "imageRef" &&
+    !isNonEmptyString(receipt.sourceAdapter.imageRef)
+  ) {
+    pushIssue(issues, "sourceAdapter.imageRef", "must be a non-empty string");
+  }
+
+  if (receipt.sourceAdapter.kind === "branch") {
+    if (!isNonEmptyString(receipt.sourceAdapter.repo)) {
+      pushIssue(issues, "sourceAdapter.repo", "must be a non-empty string");
+    }
+
+    if (!isNonEmptyString(receipt.sourceAdapter.branch)) {
+      pushIssue(issues, "sourceAdapter.branch", "must be a non-empty string");
+    }
+  }
+}
+
+function validateHealth(receipt, issues) {
+  if (receipt.health === undefined) {
+    return;
+  }
+
+  if (!isRecord(receipt.health)) {
+    pushIssue(issues, "health", "must be an object");
+    return;
+  }
+
+  if (typeof receipt.health.ok !== "boolean") {
+    pushIssue(issues, "health.ok", "must be a boolean");
+  }
+
+  if (
+    receipt.health.status !== undefined &&
+    !Number.isInteger(receipt.health.status)
+  ) {
+    pushIssue(issues, "health.status", "must be an integer");
+  }
+
+  if (
+    receipt.health.error !== undefined &&
+    !isNonEmptyString(receipt.health.error)
+  ) {
+    pushIssue(issues, "health.error", "must be a non-empty string");
+  }
+}
+
+function validatePhaseCommands(commands, phasePath, issues) {
+  if (!Array.isArray(commands)) {
+    pushIssue(issues, `${phasePath}.commands`, "must be an array");
+    return;
+  }
+
+  commands.forEach((commandResult, index) => {
+    const commandPath = `${phasePath}.commands.${index}`;
+    if (!isRecord(commandResult)) {
+      pushIssue(issues, commandPath, "must be an object");
+      return;
+    }
+
+    if (!isNonEmptyString(commandResult.command)) {
+      pushIssue(issues, `${commandPath}.command`, "must be a non-empty string");
+    }
+
+    if (
+      !isNonEmptyString(commandResult.status) ||
+      !SUPPORTED_RELEASE_PHASE_STATUSES.includes(commandResult.status)
+    ) {
+      pushIssue(
+        issues,
+        `${commandPath}.status`,
+        `must be one of: ${SUPPORTED_RELEASE_PHASE_STATUSES.join(", ")}`,
+      );
+    }
+
+    if (!Number.isInteger(commandResult.exitCode)) {
+      pushIssue(issues, `${commandPath}.exitCode`, "must be an integer");
+    }
+
+    if (
+      commandResult.signal !== undefined &&
+      !isNonEmptyString(commandResult.signal)
+    ) {
+      pushIssue(issues, `${commandPath}.signal`, "must be a non-empty string");
+    }
+  });
+}
+
+function validatePhaseResult(phaseEvidence, phaseName, issues) {
+  const phase = phaseEvidence?.[phaseName];
+  if (!isRecord(phase)) {
+    pushIssue(issues, `phaseEvidence.${phaseName}`, "must be an object");
+    return;
+  }
+
+  if (phase.phase !== phaseName) {
+    pushIssue(issues, `phaseEvidence.${phaseName}.phase`, `must equal ${phaseName}`);
+  }
+
+  if (
+    !isNonEmptyString(phase.status) ||
+    !SUPPORTED_RELEASE_PHASE_STATUSES.includes(phase.status)
+  ) {
+    pushIssue(
+      issues,
+      `phaseEvidence.${phaseName}.status`,
+      `must be one of: ${SUPPORTED_RELEASE_PHASE_STATUSES.join(", ")}`,
+    );
+  }
+
+  validatePhaseCommands(phase.commands, `phaseEvidence.${phaseName}`, issues);
+}
+
+function validateLineage(receipt, issues) {
+  if (receipt.lineage === undefined) {
+    return;
+  }
+
+  if (!isRecord(receipt.lineage)) {
+    pushIssue(issues, "lineage", "must be an object");
+    return;
+  }
+
+  if (
+    receipt.lineage.promotedFromReleaseId !== undefined &&
+    !isNonEmptyString(receipt.lineage.promotedFromReleaseId)
+  ) {
+    pushIssue(issues, "lineage.promotedFromReleaseId", "must be a non-empty string");
+  }
+
+  if (!isNonEmptyString(receipt.lineage.promotedToReleaseId)) {
+    pushIssue(issues, "lineage.promotedToReleaseId", "must be a non-empty string");
+  }
+}
+
+function validateOptionalStringField(receipt, fieldName, issues) {
+  if (receipt[fieldName] !== undefined && !isNonEmptyString(receipt[fieldName])) {
+    pushIssue(issues, fieldName, "must be a non-empty string");
+  }
+}
+
+function validatePhaseEvidence(receipt, issues) {
+  if (receipt.phaseEvidence === undefined) {
+    return;
+  }
+
+  if (!isRecord(receipt.phaseEvidence)) {
+    pushIssue(issues, "phaseEvidence", "must be an object");
+    return;
+  }
+
+  if (receipt.action === "activate") {
+    validatePhaseResult(receipt.phaseEvidence, "preActivate", issues);
+
+    if (
+      receipt.status === "succeeded" ||
+      receipt.failedPhase === "postActivate"
+    ) {
+      validatePhaseResult(receipt.phaseEvidence, "postActivate", issues);
+    }
+  }
+
+  if (receipt.action === "rollback") {
+    validatePhaseResult(receipt.phaseEvidence, "preRollback", issues);
+  }
+}
+
+export function validateWave1ReleaseReceipt(value) {
+  const issues = [];
+
+  if (!isRecord(value)) {
+    return {
+      issues: [{ path: "$", message: "release receipt must be a JSON object" }],
+    };
+  }
+
+  if (value.contractVersion !== WAVE1_RELEASE_RECEIPT_VERSION) {
+    pushIssue(
+      issues,
+      "contractVersion",
+      `must equal ${WAVE1_RELEASE_RECEIPT_VERSION}`,
+    );
+  }
+
+  if (!isNonEmptyString(value.receiptId)) {
+    pushIssue(issues, "receiptId", "must be a non-empty string");
+  }
+
+  if (
+    !isNonEmptyString(value.action) ||
+    !SUPPORTED_RELEASE_RECEIPT_ACTIONS.includes(value.action)
+  ) {
+    pushIssue(
+      issues,
+      "action",
+      `must be one of: ${SUPPORTED_RELEASE_RECEIPT_ACTIONS.join(", ")}`,
+    );
+  }
+
+  if (
+    !isNonEmptyString(value.status) ||
+    !SUPPORTED_RELEASE_RECEIPT_STATUSES.includes(value.status)
+  ) {
+    pushIssue(
+      issues,
+      "status",
+      `must be one of: ${SUPPORTED_RELEASE_RECEIPT_STATUSES.join(", ")}`,
+    );
+  }
+
+  [
+    "appName",
+    "releaseId",
+    "createdAt",
+    "releaseDirectory",
+    "releaseMetadataPath",
+    "currentPointerPath",
+    "previousPointerPath",
+  ].forEach((fieldName) => {
+    if (!isNonEmptyString(value[fieldName])) {
+      pushIssue(issues, fieldName, "must be a non-empty string");
+    }
+  });
+
+  validateReleaseTarget(value, issues);
+  validateRollbackTarget(value, issues);
+  validateSourceAdapter(value, issues);
+  validateHealth(value, issues);
+  validatePhaseEvidence(value, issues);
+  validateLineage(value, issues);
+
+  [
+    "previousReleaseId",
+    "failedPhase",
+    "preservedCurrentReleaseId",
+    "preservedPreviousReleaseId",
+  ].forEach((fieldName) => validateOptionalStringField(value, fieldName, issues));
+
+  if (
+    value.revertedPointers !== undefined &&
+    typeof value.revertedPointers !== "boolean"
+  ) {
+    pushIssue(issues, "revertedPointers", "must be a boolean");
+  }
+
+  if (value.action === "planned" && value.status !== "planned") {
+    pushIssue(issues, "status", "planned receipts must use planned status");
+  }
+
+  if (
+    (value.action === "activate" || value.action === "rollback") &&
+    value.status === "planned"
+  ) {
+    pushIssue(issues, "status", `${value.action} receipts must not use planned status`);
+  }
+
+  if (value.action === "activate" && value.status === "succeeded") {
+    if (value.health === undefined) {
+      pushIssue(issues, "health", "is required for successful activate receipts");
+    }
+
+    if (value.phaseEvidence === undefined) {
+      pushIssue(
+        issues,
+        "phaseEvidence",
+        "is required for successful activate receipts",
+      );
+    }
+
+    if (value.lineage === undefined) {
+      pushIssue(issues, "lineage", "is required for successful activate receipts");
+    }
+  }
+
+  if (value.action === "activate" && value.status === "failed") {
+    if (!isNonEmptyString(value.failedPhase)) {
+      pushIssue(issues, "failedPhase", "is required for failed activate receipts");
+    } else if (
+      !["preActivate", "healthcheck", "postActivate"].includes(value.failedPhase)
+    ) {
+      pushIssue(
+        issues,
+        "failedPhase",
+        "must be one of: preActivate, healthcheck, postActivate",
+      );
+    }
+
+    if (value.phaseEvidence === undefined) {
+      pushIssue(issues, "phaseEvidence", "is required for failed activate receipts");
+    }
+
+    if (value.failedPhase === "healthcheck" && value.health === undefined) {
+      pushIssue(
+        issues,
+        "health",
+        "is required when activate failedPhase is healthcheck",
+      );
+    }
+  }
+
+  if (value.action === "rollback") {
+    if (!isNonEmptyString(value.previousReleaseId)) {
+      pushIssue(
+        issues,
+        "previousReleaseId",
+        "is required for rollback receipts",
+      );
+    }
+  }
+
+  if (value.action === "rollback" && value.status === "succeeded") {
+    if (value.health === undefined) {
+      pushIssue(issues, "health", "is required for successful rollback receipts");
+    }
+
+    if (value.phaseEvidence === undefined) {
+      pushIssue(
+        issues,
+        "phaseEvidence",
+        "is required for successful rollback receipts",
+      );
+    }
+
+    if (value.lineage === undefined) {
+      pushIssue(issues, "lineage", "is required for successful rollback receipts");
+    } else if (!isNonEmptyString(value.lineage.promotedFromReleaseId)) {
+      pushIssue(
+        issues,
+        "lineage.promotedFromReleaseId",
+        "is required for successful rollback receipts",
+      );
+    }
+  }
+
+  if (value.action === "rollback" && value.status === "failed") {
+    if (!isNonEmptyString(value.failedPhase)) {
+      pushIssue(issues, "failedPhase", "is required for failed rollback receipts");
+    } else if (!["preRollback", "healthcheck"].includes(value.failedPhase)) {
+      pushIssue(
+        issues,
+        "failedPhase",
+        "must be one of: preRollback, healthcheck",
+      );
+    }
+
+    if (value.phaseEvidence === undefined) {
+      pushIssue(issues, "phaseEvidence", "is required for failed rollback receipts");
+    }
+
+    if (value.failedPhase === "healthcheck" && value.health === undefined) {
+      pushIssue(
+        issues,
+        "health",
+        "is required when rollback failedPhase is healthcheck",
+      );
+    }
+  }
+
+  if (
+    isNonEmptyString(value.failedPhase) &&
+    !SUPPORTED_RELEASE_RECEIPT_FAILURE_PHASES.includes(value.failedPhase)
+  ) {
+    pushIssue(
+      issues,
+      "failedPhase",
+      `must be one of: ${SUPPORTED_RELEASE_RECEIPT_FAILURE_PHASES.join(", ")}`,
+    );
+  }
+
+  return issues.length > 0 ? { issues } : { issues: [], receipt: value };
+}
+
+export function parseWave1ReleaseReceipt(raw) {
+  let parsed;
+
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    return {
+      issues: [
+        {
+          path: "$",
+          message:
+            error instanceof Error ? error.message : "could not parse JSON",
+        },
+      ],
+    };
+  }
+
+  return validateWave1ReleaseReceipt(parsed);
 }
 
 function normalizePath(filePath) {
@@ -357,6 +861,12 @@ async function writeReceipt(rootDir, appName, payload) {
     contractVersion: WAVE1_RELEASE_RECEIPT_VERSION,
     receiptId,
   };
+  const validation = validateWave1ReleaseReceipt(fullPayload);
+  if (validation.issues.length > 0) {
+    throw new Error(
+      `Invalid release receipt payload: ${JSON.stringify(validation.issues)}`,
+    );
+  }
   const receiptPath = path.join(receiptsDirectory(rootDir, appName), `${receiptId}.json`);
   await writeImmutableJson(receiptPath, fullPayload);
   return {

--- a/docs/contracts/wave1-release-receipt.md
+++ b/docs/contracts/wave1-release-receipt.md
@@ -1,0 +1,120 @@
+# Wave 1 Release Receipt Contract
+
+Wave 1 release receipts are part of the operator evidence surface. They are written under `.lifeline/releases/<app>/receipts/` for release planning, activation, rollback, and failed release transitions.
+
+## Contract version
+
+- `atlas.lifeline.release-receipt.v1`
+
+## Common fields
+
+Every release receipt includes:
+
+- `contractVersion`
+- `receiptId`
+- `action`
+- `status`
+- `appName`
+- `releaseId`
+- `createdAt`
+- `releaseDirectory`
+- `releaseMetadataPath`
+- `currentPointerPath`
+- `previousPointerPath`
+- `releaseTarget`
+- `rollbackTarget`
+
+Optional fields appear only when the transition requires them:
+
+- `previousReleaseId`
+- `sourceAdapter`
+- `health`
+- `phaseEvidence`
+- `failedPhase`
+- `preservedCurrentReleaseId`
+- `preservedPreviousReleaseId`
+- `revertedPointers`
+- `lineage`
+
+## Action variants
+
+### Planned receipt
+
+`lifeline release persist` writes a `planned` receipt:
+
+- `action=planned`
+- `status=planned`
+- no phase evidence, failed phase, or lineage
+- optional `sourceAdapter` when deploy-contract compatibility normalization occurred
+
+### Activate receipt
+
+Activation success records:
+
+- `action=activate`
+- `status=succeeded`
+- `health`
+- `phaseEvidence.preActivate`
+- `phaseEvidence.postActivate`
+- `lineage`
+- `lineage.promotedFromReleaseId` is present when the activation displaced an existing current release
+
+Activation failure records:
+
+- `action=activate`
+- `status=failed`
+- `failedPhase`
+- `phaseEvidence`
+- `health` when the failure phase is `healthcheck`
+- preserved pointer ids when the failed transition had an existing current or previous release
+- `revertedPointers=true` when `postActivate` failed after provisional pointer movement
+
+### Rollback receipt
+
+Rollback success records:
+
+- `action=rollback`
+- `status=succeeded`
+- `previousReleaseId`
+- `health`
+- `phaseEvidence.preRollback`
+- `lineage`
+- rollback success always includes both `lineage.promotedFromReleaseId` and `lineage.promotedToReleaseId`
+
+Rollback failure records:
+
+- `action=rollback`
+- `status=failed`
+- `previousReleaseId`
+- `failedPhase`
+- `phaseEvidence.preRollback`
+- `health` when the failure phase is `healthcheck`
+- preserved pointer ids for the held current and previous release lineage
+
+## Phase evidence contract
+
+Phase evidence records the concrete commands Lifeline ran before the transition continued or failed:
+
+- `phaseEvidence.<phase>.phase`
+- `phaseEvidence.<phase>.status`
+- `phaseEvidence.<phase>.commands[]`
+- `phaseEvidence.<phase>.commands[].command`
+- `phaseEvidence.<phase>.commands[].status`
+- `phaseEvidence.<phase>.commands[].exitCode`
+- optional `signal`
+
+## Rule
+
+Operator evidence must be schema-backed and deterministic before it is written to disk.
+
+## Pattern
+
+Validate release receipts at emission time and verify the emitted receipts deterministically across success and failure paths.
+
+## Failure Mode
+
+If receipt fields drift silently, status surfaces and rollback evidence can look valid while operators are actually reading an undocumented or partial contract.
+
+## Schema file
+
+- [`../../schemas/wave1-release-receipt.schema.json`](../../schemas/wave1-release-receipt.schema.json)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "verify": "pnpm typecheck && pnpm build && pnpm test:wave1-deploy-contract && pnpm test:wave1-release-mechanics && pnpm test:wave1-release-cli && pnpm test:wave1-release-replay && pnpm test:wave1-operator-evidence && pnpm test:topology-manifest && pnpm test:privileged-execution-bridge && pnpm test:privileged-execution-repair && pnpm test:ui-proof-receipt",
+    "verify": "pnpm typecheck && pnpm build && pnpm test:wave1-deploy-contract && pnpm test:wave1-release-receipt && pnpm test:wave1-release-mechanics && pnpm test:wave1-release-cli && pnpm test:wave1-release-replay && pnpm test:wave1-operator-evidence && pnpm test:topology-manifest && pnpm test:privileged-execution-bridge && pnpm test:privileged-execution-repair && pnpm test:ui-proof-receipt",
     "check": "biome check .",
     "format": "biome format --write .",
     "validate:fitness": "node dist/cli.js validate examples/fitness-app.lifeline.yml",
@@ -62,6 +62,7 @@
     "smoke:runtime:up-malformed-env-file": "node scripts/smoke-runtime-up-malformed-env-file.mjs",
     "smoke:runtime:restore-missing-env-file": "node scripts/smoke-runtime-restore-missing-env-file.mjs",
     "test:wave1-deploy-contract": "node tests/contracts/test-wave1-deploy-contract-deterministic.mjs",
+    "test:wave1-release-receipt": "node tests/contracts/test-wave1-release-receipt-contract-deterministic.mjs",
     "test:wave1-release-mechanics": "node scripts/test-wave1-release-mechanics-deterministic.mjs",
     "test:wave1-release-cli": "node scripts/test-wave1-release-cli-deterministic.mjs",
     "test:wave1-operator-evidence": "node scripts/test-wave1-operator-evidence-deterministic.mjs",

--- a/schemas/wave1-release-receipt.schema.json
+++ b/schemas/wave1-release-receipt.schema.json
@@ -1,0 +1,483 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:atlas:lifeline:wave1:release-receipt:v1",
+  "title": "Wave 1 Lifeline Release Receipt",
+  "type": "object",
+  "required": [
+    "contractVersion",
+    "receiptId",
+    "action",
+    "status",
+    "appName",
+    "releaseId",
+    "createdAt",
+    "releaseDirectory",
+    "releaseMetadataPath",
+    "currentPointerPath",
+    "previousPointerPath",
+    "releaseTarget",
+    "rollbackTarget"
+  ],
+  "properties": {
+    "contractVersion": {
+      "const": "atlas.lifeline.release-receipt.v1"
+    },
+    "receiptId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "action": {
+      "enum": [
+        "planned",
+        "activate",
+        "rollback"
+      ]
+    },
+    "status": {
+      "enum": [
+        "planned",
+        "succeeded",
+        "failed"
+      ]
+    },
+    "appName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "releaseId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "previousReleaseId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "createdAt": {
+      "type": "string",
+      "minLength": 1
+    },
+    "releaseDirectory": {
+      "type": "string",
+      "minLength": 1
+    },
+    "releaseMetadataPath": {
+      "type": "string",
+      "minLength": 1
+    },
+    "currentPointerPath": {
+      "type": "string",
+      "minLength": 1
+    },
+    "previousPointerPath": {
+      "type": "string",
+      "minLength": 1
+    },
+    "releaseTarget": {
+      "type": "object",
+      "required": [
+        "kind",
+        "releaseId",
+        "artifactRef"
+      ],
+      "properties": {
+        "kind": {
+          "const": "single-host-immutable"
+        },
+        "releaseId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "artifactRef": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "rollbackTarget": {
+      "type": "object",
+      "required": [
+        "releaseId",
+        "artifactRef",
+        "strategy"
+      ],
+      "properties": {
+        "releaseId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "artifactRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "strategy": {
+          "enum": [
+            "redeploy",
+            "restore"
+          ]
+        },
+        "note": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "sourceAdapter": {
+      "type": "object",
+      "required": [
+        "kind",
+        "canonicalArtifactRef"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "artifactRef",
+            "imageRef",
+            "branch"
+          ]
+        },
+        "canonicalArtifactRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "artifactRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "imageRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repo": {
+          "type": "string",
+          "minLength": 1
+        },
+        "branch": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "health": {
+      "type": "object",
+      "required": [
+        "ok"
+      ],
+      "properties": {
+        "ok": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "integer"
+        },
+        "error": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "phaseEvidence": {
+      "type": "object",
+      "properties": {
+        "preActivate": {
+          "$ref": "#/$defs/phaseResult"
+        },
+        "postActivate": {
+          "$ref": "#/$defs/phaseResult"
+        },
+        "preRollback": {
+          "$ref": "#/$defs/phaseResult"
+        }
+      },
+      "additionalProperties": false
+    },
+    "failedPhase": {
+      "enum": [
+        "preActivate",
+        "healthcheck",
+        "postActivate",
+        "preRollback"
+      ]
+    },
+    "preservedCurrentReleaseId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "preservedPreviousReleaseId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "revertedPointers": {
+      "type": "boolean"
+    },
+    "lineage": {
+      "type": "object",
+      "required": [
+        "promotedToReleaseId"
+      ],
+      "properties": {
+        "promotedFromReleaseId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "promotedToReleaseId": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "phaseCommand": {
+      "type": "object",
+      "required": [
+        "command",
+        "status",
+        "exitCode"
+      ],
+      "properties": {
+        "command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "enum": [
+            "succeeded",
+            "failed"
+          ]
+        },
+        "exitCode": {
+          "type": "integer"
+        },
+        "signal": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "phaseResult": {
+      "type": "object",
+      "required": [
+        "phase",
+        "status",
+        "commands"
+      ],
+      "properties": {
+        "phase": {
+          "enum": [
+            "preActivate",
+            "postActivate",
+            "preRollback"
+          ]
+        },
+        "status": {
+          "enum": [
+            "succeeded",
+            "failed"
+          ]
+        },
+        "commands": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/phaseCommand"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "action": {
+            "const": "planned"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "status": {
+            "const": "planned"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "action": {
+            "const": "activate"
+          },
+          "status": {
+            "const": "succeeded"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "health",
+          "phaseEvidence",
+          "lineage"
+        ],
+        "properties": {
+          "phaseEvidence": {
+            "required": [
+              "preActivate",
+              "postActivate"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "action": {
+            "const": "activate"
+          },
+          "status": {
+            "const": "failed"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "failedPhase",
+          "phaseEvidence"
+        ],
+        "properties": {
+          "failedPhase": {
+            "enum": [
+              "preActivate",
+              "healthcheck",
+              "postActivate"
+            ]
+          },
+          "phaseEvidence": {
+            "required": [
+              "preActivate"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "action": {
+            "const": "activate"
+          },
+          "failedPhase": {
+            "const": "postActivate"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "phaseEvidence": {
+            "required": [
+              "postActivate"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "action": {
+            "const": "rollback"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "previousReleaseId"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "action": {
+            "const": "rollback"
+          },
+          "status": {
+            "const": "succeeded"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "health",
+          "phaseEvidence",
+          "lineage"
+        ],
+        "properties": {
+          "lineage": {
+            "required": [
+              "promotedFromReleaseId"
+            ]
+          },
+          "phaseEvidence": {
+            "required": [
+              "preRollback"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "action": {
+            "const": "rollback"
+          },
+          "status": {
+            "const": "failed"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "failedPhase",
+          "phaseEvidence"
+        ],
+        "properties": {
+          "failedPhase": {
+            "enum": [
+              "preRollback",
+              "healthcheck"
+            ]
+          },
+          "phaseEvidence": {
+            "required": [
+              "preRollback"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "failedPhase": {
+            "const": "healthcheck"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "health"
+        ]
+      }
+    }
+  ],
+  "additionalProperties": false
+}

--- a/scripts/test-wave1-release-mechanics-deterministic.mjs
+++ b/scripts/test-wave1-release-mechanics-deterministic.mjs
@@ -10,9 +10,11 @@ import {
 } from "../control-plane/wave1-deploy-contract.mjs";
 import {
   activateWave1Release,
+  parseWave1ReleaseReceipt,
   persistWave1Release,
   readWave1ReleaseState,
   rollbackWave1Release,
+  validateWave1ReleaseReceipt,
 } from "../control-plane/wave1-release-engine.mjs";
 
 function createManifest({
@@ -183,6 +185,7 @@ try {
   assert.equal(releaseA.validation.status, "passed");
   assert.equal(releaseA.receipt.action, "planned");
   assert.equal(releaseA.receipt.releaseId, "release-20260425-0001");
+  assert.equal(validateWave1ReleaseReceipt(releaseA.receipt).issues.length, 0);
   assert.equal(
     releaseA.receipt.releaseMetadataPath,
     ".lifeline/releases/lifeline-pilot/release-20260425-0001/metadata.json",
@@ -288,6 +291,7 @@ try {
   assert.equal(activationA.ok, true);
   assert.equal(activationA.current.releaseId, releaseA.releaseId);
   assert.equal(activationA.previous, undefined);
+  assert.equal(validateWave1ReleaseReceipt(activationA.receipt).issues.length, 0);
   assert.equal(activationA.receipt.phaseEvidence.preActivate.status, "succeeded");
   assert.equal(activationA.receipt.phaseEvidence.postActivate.status, "succeeded");
   assert.deepEqual(await readHookLogLines(hookLogPath), [
@@ -322,6 +326,7 @@ try {
   assert.equal(activationB.ok, true);
   assert.equal(activationB.current.releaseId, releaseB.releaseId);
   assert.equal(activationB.previous.releaseId, releaseA.releaseId);
+  assert.equal(validateWave1ReleaseReceipt(activationB.receipt).issues.length, 0);
   assert.equal(activationB.receipt.phaseEvidence.preActivate.status, "succeeded");
   assert.equal(activationB.receipt.phaseEvidence.postActivate.status, "succeeded");
   assert.equal(
@@ -375,6 +380,7 @@ try {
   assert.equal(failedActivation.ok, false);
   assert.equal(failedActivation.current.releaseId, releaseB.releaseId);
   assert.equal(failedActivation.previous.releaseId, releaseA.releaseId);
+  assert.equal(validateWave1ReleaseReceipt(failedActivation.receipt).issues.length, 0);
   assert.equal(failedActivation.receipt.status, "failed");
   assert.equal(failedActivation.receipt.failedPhase, "preActivate");
   assert.equal(failedActivation.receipt.phaseEvidence.preActivate.status, "failed");
@@ -401,6 +407,7 @@ try {
   assert.equal(rollbackResult.ok, true);
   assert.equal(rollbackResult.current.releaseId, releaseA.releaseId);
   assert.equal(rollbackResult.previous.releaseId, releaseB.releaseId);
+  assert.equal(validateWave1ReleaseReceipt(rollbackResult.receipt).issues.length, 0);
   assert.equal(rollbackResult.receipt.action, "rollback");
   assert.equal(rollbackResult.receipt.status, "succeeded");
   assert.equal(rollbackResult.receipt.previousReleaseId, releaseB.releaseId);
@@ -422,6 +429,10 @@ try {
     tempRoot,
     activationB.receipt.receiptPath,
   );
+  assert.equal(
+    parseWave1ReleaseReceipt(JSON.stringify(activationReceipt, null, 2)).issues.length,
+    0,
+  );
   assert.equal(activationReceipt.releaseId, releaseB.releaseId);
   assert.equal(activationReceipt.action, "activate");
   assert.equal(
@@ -432,6 +443,10 @@ try {
   const rollbackReceipt = await readJson(
     tempRoot,
     rollbackResult.receipt.receiptPath,
+  );
+  assert.equal(
+    parseWave1ReleaseReceipt(JSON.stringify(rollbackReceipt, null, 2)).issues.length,
+    0,
   );
   assert.equal(rollbackReceipt.releaseId, releaseA.releaseId);
   assert.equal(rollbackReceipt.previousReleaseId, releaseB.releaseId);
@@ -467,6 +482,7 @@ try {
   assert.equal(legacyActivation.ok, true);
   assert.equal(legacyActivation.current.releaseId, legacyReleaseId);
   assert.equal(legacyActivation.previous.releaseId, releaseA.releaseId);
+  assert.equal(validateWave1ReleaseReceipt(legacyActivation.receipt).issues.length, 0);
   assert.deepEqual(legacyActivation.receipt.releaseTarget, {
     kind: "single-host-immutable",
     releaseId: legacyReleaseId,
@@ -507,6 +523,7 @@ try {
   assert.equal(legacyRollback.ok, true);
   assert.equal(legacyRollback.current.releaseId, legacyReleaseId);
   assert.equal(legacyRollback.previous.releaseId, releaseD.releaseId);
+  assert.equal(validateWave1ReleaseReceipt(legacyRollback.receipt).issues.length, 0);
   assert.deepEqual(legacyRollback.receipt.releaseTarget, {
     kind: "single-host-immutable",
     releaseId: legacyMetadata.releaseId,
@@ -576,6 +593,7 @@ try {
   assert.equal(blockedRollback.ok, false);
   assert.equal(blockedRollback.current.releaseId, rollbackTargetRelease.releaseId);
   assert.equal(blockedRollback.previous.releaseId, rollbackBlockerRelease.releaseId);
+  assert.equal(validateWave1ReleaseReceipt(blockedRollback.receipt).issues.length, 0);
   assert.equal(blockedRollback.receipt.failedPhase, "preRollback");
   assert.equal(blockedRollback.receipt.phaseEvidence.preRollback.status, "failed");
   assert.equal(

--- a/tests/contracts/test-wave1-release-receipt-contract-deterministic.mjs
+++ b/tests/contracts/test-wave1-release-receipt-contract-deterministic.mjs
@@ -1,0 +1,199 @@
+import { readFile } from "node:fs/promises";
+import { strict as assert } from "node:assert";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import {
+  parseWave1ReleaseReceipt,
+  validateWave1ReleaseReceipt,
+  WAVE1_RELEASE_RECEIPT_VERSION,
+} from "../../control-plane/wave1-release-engine.mjs";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+const receiptSchemaPath = path.join(
+  repoRoot,
+  "schemas/wave1-release-receipt.schema.json",
+);
+const docsPath = path.join(
+  repoRoot,
+  "docs/contracts/wave1-release-receipt.md",
+);
+
+function buildBaseReceipt(overrides = {}) {
+  return {
+    contractVersion: WAVE1_RELEASE_RECEIPT_VERSION,
+    receiptId: "receipt-0001",
+    action: "planned",
+    status: "planned",
+    appName: "lifeline-pilot",
+    releaseId: "release-20260511-0001",
+    createdAt: "2026-05-11T18:15:00.000Z",
+    releaseDirectory: ".lifeline/releases/lifeline-pilot/release-20260511-0001",
+    releaseMetadataPath:
+      ".lifeline/releases/lifeline-pilot/release-20260511-0001/metadata.json",
+    currentPointerPath: ".lifeline/releases/lifeline-pilot/current.json",
+    previousPointerPath: ".lifeline/releases/lifeline-pilot/previous.json",
+    releaseTarget: {
+      kind: "single-host-immutable",
+      releaseId: "release-20260511-0001",
+      artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    },
+    rollbackTarget: {
+      releaseId: "release-20260510-0007",
+      artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      strategy: "restore",
+    },
+    ...overrides,
+  };
+}
+
+function buildPhaseEvidence(phaseName, status = "succeeded") {
+  return {
+    [phaseName]: {
+      phase: phaseName,
+      status,
+      commands: [
+        {
+          command: `node hook-runner.mjs ${phaseName}`,
+          status,
+          exitCode: status === "succeeded" ? 0 : 1,
+        },
+      ],
+    },
+  };
+}
+
+const receiptSchema = JSON.parse(await readFile(receiptSchemaPath, "utf8"));
+const docs = await readFile(docsPath, "utf8");
+
+const plannedReceipt = buildBaseReceipt({
+  sourceAdapter: {
+    kind: "imageRef",
+    imageRef:
+      "ghcr.io/fawxzzy/lifeline-pilot@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    canonicalArtifactRef:
+      "ghcr.io/fawxzzy/lifeline-pilot@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  },
+});
+assert.equal(validateWave1ReleaseReceipt(plannedReceipt).issues.length, 0);
+
+const activateSuccessReceipt = buildBaseReceipt({
+  receiptId: "receipt-activate-success",
+  action: "activate",
+  status: "succeeded",
+  previousReleaseId: "release-20260510-0007",
+  health: {
+    ok: true,
+    status: 200,
+  },
+  phaseEvidence: {
+    ...buildPhaseEvidence("preActivate"),
+    ...buildPhaseEvidence("postActivate"),
+  },
+  lineage: {
+    promotedFromReleaseId: "release-20260510-0007",
+    promotedToReleaseId: "release-20260511-0001",
+  },
+});
+assert.equal(validateWave1ReleaseReceipt(activateSuccessReceipt).issues.length, 0);
+
+const activateFailureReceipt = buildBaseReceipt({
+  receiptId: "receipt-activate-failed",
+  action: "activate",
+  status: "failed",
+  previousReleaseId: "release-20260510-0007",
+  failedPhase: "healthcheck",
+  health: {
+    ok: false,
+    status: 503,
+    error: "health gate rejected candidate",
+  },
+  phaseEvidence: buildPhaseEvidence("preActivate"),
+  preservedCurrentReleaseId: "release-20260510-0007",
+});
+assert.equal(validateWave1ReleaseReceipt(activateFailureReceipt).issues.length, 0);
+
+const rollbackSuccessReceipt = buildBaseReceipt({
+  receiptId: "receipt-rollback-success",
+  action: "rollback",
+  status: "succeeded",
+  previousReleaseId: "release-20260511-0001",
+  health: {
+    ok: true,
+    status: 200,
+  },
+  phaseEvidence: buildPhaseEvidence("preRollback"),
+  lineage: {
+    promotedFromReleaseId: "release-20260511-0001",
+    promotedToReleaseId: "release-20260510-0007",
+  },
+});
+assert.equal(validateWave1ReleaseReceipt(rollbackSuccessReceipt).issues.length, 0);
+
+const rollbackFailureReceipt = buildBaseReceipt({
+  receiptId: "receipt-rollback-failed",
+  action: "rollback",
+  status: "failed",
+  previousReleaseId: "release-20260511-0001",
+  failedPhase: "preRollback",
+  phaseEvidence: buildPhaseEvidence("preRollback", "failed"),
+  preservedCurrentReleaseId: "release-20260511-0001",
+  preservedPreviousReleaseId: "release-20260510-0007",
+});
+assert.equal(validateWave1ReleaseReceipt(rollbackFailureReceipt).issues.length, 0);
+
+const missingFailedPhase = validateWave1ReleaseReceipt({
+  ...activateFailureReceipt,
+  failedPhase: undefined,
+});
+assert(
+  missingFailedPhase.issues.some((issue) => issue.path === "failedPhase"),
+  `expected failedPhase issue, got ${JSON.stringify(missingFailedPhase.issues)}`,
+);
+
+const missingPhaseEvidence = validateWave1ReleaseReceipt({
+  ...rollbackFailureReceipt,
+  phaseEvidence: undefined,
+});
+assert(
+  missingPhaseEvidence.issues.some((issue) => issue.path === "phaseEvidence"),
+  `expected phaseEvidence issue, got ${JSON.stringify(missingPhaseEvidence.issues)}`,
+);
+
+const roundTrip = parseWave1ReleaseReceipt(JSON.stringify(activateSuccessReceipt, null, 2));
+assert.equal(roundTrip.issues.length, 0);
+assert.deepEqual(roundTrip.receipt, activateSuccessReceipt);
+
+assert.equal(
+  receiptSchema.properties.contractVersion.const,
+  WAVE1_RELEASE_RECEIPT_VERSION,
+);
+assert.deepEqual(receiptSchema.properties.action.enum, [
+  "planned",
+  "activate",
+  "rollback",
+]);
+assert.deepEqual(receiptSchema.properties.status.enum, [
+  "planned",
+  "succeeded",
+  "failed",
+]);
+assert.ok(
+  receiptSchema.allOf.some((rule) =>
+    rule.then?.required?.includes("phaseEvidence") &&
+    rule.then?.required?.includes("failedPhase")),
+  "release receipt schema should require phaseEvidence and failedPhase for failure flows",
+);
+assert.ok(
+  docs.includes("atlas.lifeline.release-receipt.v1") &&
+    docs.includes("action=planned") &&
+    docs.includes("action=activate") &&
+    docs.includes("action=rollback") &&
+    docs.includes("failedPhase") &&
+    docs.includes("phaseEvidence") &&
+    docs.includes("Operator evidence must be schema-backed and deterministic before it is written to disk") &&
+    docs.includes("Validate release receipts at emission time and verify the emitted receipts deterministically across success and failure paths"),
+  "release receipt contract doc should describe the receipt variants and operator evidence rule",
+);
+
+console.log("Wave 1 release receipt contract deterministic checks passed");


### PR DESCRIPTION
## Summary

- add an explicit Wave 1 release receipt schema and contract doc for planned, activate, rollback, and failed release transitions
- validate release receipts at write time before persisting them under `.lifeline/releases/<app>/receipts/`
- add deterministic receipt-contract coverage plus release-mechanics assertions that emitted receipts still satisfy the contract
- wire the dedicated receipt-contract test into `pnpm run verify`

## Kept in this refresh

- explicit release receipt schema
- write-time receipt validation before persistence
- dedicated release receipt contract test
- release-mechanics coverage for emitted receipt validation
- receipt contract doc

## Dropped from the older branch

- `src/core/release-state.ts` receipt-health overlap already landed on `main`
- operator-surface and broader evidence wording already covered by merged Waves 1-3
- any destructive pointer, replay, or rollback-confidence work already merged separately

## Verification

- `pnpm install --frozen-lockfile`
- `node tests/contracts/test-wave1-release-receipt-contract-deterministic.mjs`
- `node scripts/test-wave1-release-mechanics-deterministic.mjs`
- `pnpm run verify`

## Scope note

This refresh stays inside receipt schema parity and deterministic receipt verification only. It does not add hosted control-plane behavior, preview hosting, domain automation, TLS automation, multi-node orchestration, or broader runtime authority.