### PR TITLE
Lifeline: summarize release receipt health

### DIFF
--- a/scripts/test-wave1-operator-evidence-deterministic.mjs
+++ b/scripts/test-wave1-operator-evidence-deterministic.mjs
@@ -216,6 +216,31 @@ try {
     checkHealth: async () => ({ ok: true, status: 200 }),
   });
 
+  const receiptsDir = path.join(
+    tempWorkspace,
+    ".lifeline",
+    "releases",
+    appName,
+    "receipts",
+  );
+  await writeFile(
+    path.join(receiptsDir, "mismatched-receipt.json"),
+    JSON.stringify({
+      contractVersion: "atlas.lifeline.release-receipt.v0",
+      receiptId: "mismatched-receipt",
+      action: "activate",
+      status: "succeeded",
+      releaseId: "release-runtime-smoke-app-z",
+      createdAt: "2026-04-26T00:06:00.000Z",
+    }, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    path.join(receiptsDir, "unreadable-receipt.json"),
+    "{not-json",
+    "utf8",
+  );
+
   const statusResult = await runCli(["status", appName], {
     cwd: tempWorkspace,
     allowFailure: true,
@@ -232,6 +257,21 @@ try {
   assertIncludes(statusResult.stdout, "- rollbackTarget.artifactRef: docker://runtime-smoke-app:release-a", "status: missing rollback artifact ref");
   assertIncludes(statusResult.stdout, "- rollbackTarget.strategy: restore", "status: missing rollback strategy");
   assertIncludes(statusResult.stdout, "- rollbackReady: yes", "status: missing rollback readiness");
+  assertIncludes(
+    statusResult.stdout,
+    "- receiptContractVersion: atlas.lifeline.release-receipt.v1",
+    "status: missing receipt contract version",
+  );
+  assertIncludes(
+    statusResult.stdout,
+    "- receiptHealth: degraded (versionMismatch=1, unreadable=1)",
+    "status: missing degraded receipt health summary",
+  );
+  assertIncludes(
+    statusResult.stdout,
+    "- latestReceipt: ",
+    "status: missing latest receipt summary",
+  );
   assertIncludes(statusResult.stdout, "- latestRollbackReceipt: rollback succeeded release-runtime-smoke-app-a", "status: missing rollback rehearsal receipt");
   assertIncludes(statusResult.stdout, "- receiptsDir: .lifeline/releases/runtime-smoke-app/receipts", "status: missing receipts dir");
   assertIncludes(statusResult.stdout, "- receipt: activate succeeded release-runtime-smoke-app-b", "status: missing receipt summary");
@@ -249,6 +289,21 @@ try {
   assertIncludes(proofResult.stdout, "- previousReleaseId: release-runtime-smoke-app-a", "proof-text: missing previous release id");
   assertIncludes(proofResult.stdout, "- rollbackTarget: release-runtime-smoke-app-a (restore)", "proof-text: missing rollback target");
   assertIncludes(proofResult.stdout, "- rollbackReady: yes", "proof-text: missing rollback readiness");
+  assertIncludes(
+    proofResult.stdout,
+    "- receiptContractVersion: atlas.lifeline.release-receipt.v1",
+    "proof-text: missing receipt contract version",
+  );
+  assertIncludes(
+    proofResult.stdout,
+    "- receiptHealth: degraded (versionMismatch=1, unreadable=1)",
+    "proof-text: missing degraded receipt health summary",
+  );
+  assertIncludes(
+    proofResult.stdout,
+    "- latestReceipt: ",
+    "proof-text: missing latest receipt summary",
+  );
   assertIncludes(proofResult.stdout, "- latestRollbackReceipt: rollback succeeded release-runtime-smoke-app-a", "proof-text: missing rollback rehearsal receipt");
 
   const logsResult = await runCli(["logs", appName, "20"], {
@@ -263,6 +318,21 @@ try {
   assertIncludes(logsResult.stdout, `=== lifeline logs ${appName} ===`, "logs: missing evidence header");
   assertIncludes(logsResult.stdout, "- currentReleaseId: release-runtime-smoke-app-b", "logs: missing current release id");
   assertIncludes(logsResult.stdout, "- previousReleaseId: release-runtime-smoke-app-a", "logs: missing previous release id");
+  assertIncludes(
+    logsResult.stdout,
+    "- receiptContractVersion: atlas.lifeline.release-receipt.v1",
+    "logs: missing receipt contract version",
+  );
+  assertIncludes(
+    logsResult.stdout,
+    "- latestReceipt: ",
+    "logs: missing latest receipt summary",
+  );
+  assertIncludes(
+    logsResult.stdout,
+    "- receiptHealth: degraded (versionMismatch=1, unreadable=1)",
+    "logs: missing degraded receipt health summary",
+  );
   assertIncludes(logsResult.stdout, "=== lifeline up ", "logs: missing startup header");
   assertIncludes(logsResult.stdout, `runtime-smoke-app listening on ${port}`, "logs: missing app startup line");
 

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -28,6 +28,36 @@ export async function runLogsCommand(
     if (releaseEvidence.previous) {
       console.log(`- previousReleaseId: ${releaseEvidence.previous.releaseId}`);
     }
+    console.log(`- receiptContractVersion: ${releaseEvidence.receiptHealth.contractVersion}`);
+    if (releaseEvidence.latestReceipt) {
+      console.log(
+        `- latestReceipt: ${releaseEvidence.latestReceipt.receiptId} ${releaseEvidence.latestReceipt.action} ${releaseEvidence.latestReceipt.status} ${releaseEvidence.latestReceipt.releaseId} (${releaseEvidence.latestReceipt.path})`,
+      );
+    }
+    if (releaseEvidence.receiptHealth.status === "ok") {
+      console.log("- receiptHealth: ok");
+    } else {
+      const reasons = [];
+      if (releaseEvidence.receiptHealth.versionMismatchCount > 0) {
+        reasons.push(
+          `versionMismatch=${releaseEvidence.receiptHealth.versionMismatchCount}`,
+        );
+      }
+      if (releaseEvidence.receiptHealth.invalidReceiptCount > 0) {
+        reasons.push(`invalid=${releaseEvidence.receiptHealth.invalidReceiptCount}`);
+      }
+      if (releaseEvidence.receiptHealth.unreadableReceiptCount > 0) {
+        reasons.push(
+          `unreadable=${releaseEvidence.receiptHealth.unreadableReceiptCount}`,
+        );
+      }
+      if (releaseEvidence.receiptHealth.missingLatestReceipt) {
+        reasons.push("missingLatestReceipt=yes");
+      }
+      console.log(
+        `- receiptHealth: degraded${reasons.length > 0 ? ` (${reasons.join(", ")})` : ""}`,
+      );
+    }
     console.log("");
   }
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -85,6 +85,32 @@ function deriveProof(snapshot: RuntimeSnapshot): {
   };
 }
 
+function formatReceiptHealthSummary(
+  health: NonNullable<RuntimeSnapshot["release"]>["receiptHealth"],
+): string {
+  if (health.status === "ok") {
+    return "ok";
+  }
+
+  const reasons = [];
+  if (health.versionMismatchCount > 0) {
+    reasons.push(`versionMismatch=${health.versionMismatchCount}`);
+  }
+  if (health.invalidReceiptCount > 0) {
+    reasons.push(`invalid=${health.invalidReceiptCount}`);
+  }
+  if (health.unreadableReceiptCount > 0) {
+    reasons.push(`unreadable=${health.unreadableReceiptCount}`);
+  }
+  if (health.missingLatestReceipt) {
+    reasons.push("missingLatestReceipt=yes");
+  }
+
+  return reasons.length > 0
+    ? `degraded (${reasons.join(", ")})`
+    : "degraded";
+}
+
 function serializeProofPayload(snapshot: RuntimeSnapshot): {
   mode: "proof";
   proof: {
@@ -119,6 +145,23 @@ function serializeProofPayload(snapshot: RuntimeSnapshot): {
       note?: string;
     };
     rollback_ready: boolean;
+    receipt_health: {
+      status: string;
+      contract_version: string;
+      valid_receipt_count: number;
+      version_mismatch_count: number;
+      invalid_receipt_count: number;
+      unreadable_receipt_count: number;
+      missing_latest_receipt: boolean;
+    };
+    latest_receipt?: {
+      receipt_id: string;
+      action: string;
+      status: string;
+      release_id: string;
+      contract_version: string;
+      path: string;
+    };
     latest_rollback_receipt?: {
       receipt_id: string;
       action: string;
@@ -163,14 +206,39 @@ function serializeProofPayload(snapshot: RuntimeSnapshot): {
             }
           : {}),
         rollback_ready: snapshot.release.rollbackReady,
+        receipt_health: {
+          status: snapshot.release.receiptHealth.status,
+          contract_version: snapshot.release.receiptHealth.contractVersion,
+          valid_receipt_count: snapshot.release.receiptHealth.validReceiptCount,
+          version_mismatch_count:
+            snapshot.release.receiptHealth.versionMismatchCount,
+          invalid_receipt_count: snapshot.release.receiptHealth.invalidReceiptCount,
+          unreadable_receipt_count:
+            snapshot.release.receiptHealth.unreadableReceiptCount,
+          missing_latest_receipt:
+            snapshot.release.receiptHealth.missingLatestReceipt,
+        },
         receipts_dir: snapshot.release.receiptsDir,
         latest_receipts: snapshot.release.latestReceipts.map((receipt) => ({
           receipt_id: receipt.receiptId,
           action: receipt.action,
           status: receipt.status,
           release_id: receipt.releaseId,
+          contract_version: receipt.contractVersion,
           path: receipt.path,
         })),
+        ...(snapshot.release.latestReceipt
+          ? {
+              latest_receipt: {
+                receipt_id: snapshot.release.latestReceipt.receiptId,
+                action: snapshot.release.latestReceipt.action,
+                status: snapshot.release.latestReceipt.status,
+                release_id: snapshot.release.latestReceipt.releaseId,
+                contract_version: snapshot.release.latestReceipt.contractVersion,
+                path: snapshot.release.latestReceipt.path,
+              },
+            }
+          : {}),
         ...(snapshot.release.latestRollbackReceipt
           ? {
               latest_rollback_receipt: {
@@ -178,6 +246,8 @@ function serializeProofPayload(snapshot: RuntimeSnapshot): {
                 action: snapshot.release.latestRollbackReceipt.action,
                 status: snapshot.release.latestRollbackReceipt.status,
                 release_id: snapshot.release.latestRollbackReceipt.releaseId,
+                contract_version:
+                  snapshot.release.latestRollbackReceipt.contractVersion,
                 path: snapshot.release.latestRollbackReceipt.path,
               },
             }
@@ -247,6 +317,26 @@ function printProofText(payload: ReturnType<typeof serializeProofPayload>): void
   }
   if (payload.release) {
     console.log(`- rollbackReady: ${payload.release.rollback_ready ? "yes" : "no"}`);
+    console.log(
+      `- receiptContractVersion: ${payload.release.receipt_health.contract_version}`,
+    );
+    console.log(
+      `- receiptHealth: ${formatReceiptHealthSummary({
+        status: payload.release.receipt_health.status as "ok" | "degraded",
+        contractVersion: payload.release.receipt_health.contract_version,
+        validReceiptCount: payload.release.receipt_health.valid_receipt_count,
+        versionMismatchCount: payload.release.receipt_health.version_mismatch_count,
+        invalidReceiptCount: payload.release.receipt_health.invalid_receipt_count,
+        unreadableReceiptCount: payload.release.receipt_health.unreadable_receipt_count,
+        missingLatestReceipt: payload.release.receipt_health.missing_latest_receipt,
+      })}`,
+    );
+  }
+  if (payload.release?.latest_receipt) {
+    const receipt = payload.release.latest_receipt;
+    console.log(
+      `- latestReceipt: ${receipt.receipt_id} ${receipt.action} ${receipt.status} ${receipt.release_id} (${receipt.path})`,
+    );
   }
   if (payload.release?.latest_rollback_receipt) {
     const receipt = payload.release.latest_rollback_receipt;
@@ -410,6 +500,15 @@ export async function runStatusCommand(
   }
   if (releaseEvidence) {
     console.log(`- rollbackReady: ${releaseEvidence.rollbackReady ? "yes" : "no"}`);
+    console.log(`- receiptContractVersion: ${releaseEvidence.receiptHealth.contractVersion}`);
+    console.log(
+      `- receiptHealth: ${formatReceiptHealthSummary(releaseEvidence.receiptHealth)}`,
+    );
+  }
+  if (releaseEvidence?.latestReceipt) {
+    console.log(
+      `- latestReceipt: ${releaseEvidence.latestReceipt.receiptId} ${releaseEvidence.latestReceipt.action} ${releaseEvidence.latestReceipt.status} ${releaseEvidence.latestReceipt.releaseId} (${releaseEvidence.latestReceipt.path})`,
+    );
   }
   if (releaseEvidence?.latestRollbackReceipt) {
     console.log(

--- a/src/core/release-state.ts
+++ b/src/core/release-state.ts
@@ -1,6 +1,8 @@
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
+const WAVE1_RELEASE_RECEIPT_VERSION = "atlas.lifeline.release-receipt.v1";
+
 export interface ReleasePointer {
   releaseId: string;
   updatedAt: string;
@@ -27,8 +29,19 @@ export interface ReleaseReceiptSummary {
   action: string;
   status: string;
   releaseId: string;
+  contractVersion: string;
   createdAt?: string;
   path: string;
+}
+
+export interface ReleaseReceiptHealthSummary {
+  status: "ok" | "degraded";
+  contractVersion: string;
+  validReceiptCount: number;
+  versionMismatchCount: number;
+  invalidReceiptCount: number;
+  unreadableReceiptCount: number;
+  missingLatestReceipt: boolean;
 }
 
 export interface ReleaseOperatorEvidence {
@@ -37,7 +50,9 @@ export interface ReleaseOperatorEvidence {
   rollbackTarget?: ReleaseRollbackTarget;
   receiptsDir: string;
   rollbackReady: boolean;
+  latestReceipt?: ReleaseReceiptSummary;
   latestRollbackReceipt?: ReleaseReceiptSummary;
+  receiptHealth: ReleaseReceiptHealthSummary;
   latestReceipts: ReleaseReceiptSummary[];
 }
 
@@ -153,9 +168,16 @@ async function readReleaseRecord(
 async function readLatestReceipts(
   rootDir: string,
   receiptsDir: string,
-): Promise<ReleaseReceiptSummary[]> {
+): Promise<{
+  latestReceipts: ReleaseReceiptSummary[];
+  latestReceipt?: ReleaseReceiptSummary;
+  receiptHealth: ReleaseReceiptHealthSummary;
+}> {
   const entries = (await readdir(receiptsDir).catch(() => [])) as string[];
   const receipts: Array<ReleaseReceiptSummary & { sortAt: number }> = [];
+  let versionMismatchCount = 0;
+  let invalidReceiptCount = 0;
+  let unreadableReceiptCount = 0;
 
   for (const entry of entries) {
     if (!entry.endsWith(".json")) {
@@ -164,7 +186,18 @@ async function readLatestReceipts(
 
     const receiptPath = path.join(receiptsDir, entry);
     const parsed = await readJsonIfPresent(receiptPath);
+    if (parsed === undefined) {
+      unreadableReceiptCount += 1;
+      continue;
+    }
+
     if (!isRecord(parsed)) {
+      invalidReceiptCount += 1;
+      continue;
+    }
+
+    if (parsed.contractVersion !== WAVE1_RELEASE_RECEIPT_VERSION) {
+      versionMismatchCount += 1;
       continue;
     }
 
@@ -174,6 +207,7 @@ async function readLatestReceipts(
       !isNonEmptyString(parsed.status) ||
       !isNonEmptyString(parsed.releaseId)
     ) {
+      invalidReceiptCount += 1;
       continue;
     }
 
@@ -186,16 +220,37 @@ async function readLatestReceipts(
       action: parsed.action,
       status: parsed.status,
       releaseId: parsed.releaseId,
+      contractVersion: parsed.contractVersion,
       ...(createdAt ? { createdAt } : {}),
       path: normalizeRelativePath(rootDir, receiptPath),
       sortAt: Number.isNaN(sortAt) ? 0 : sortAt,
     });
   }
 
-  return receipts
+  const latestReceipts = receipts
     .sort((left, right) => right.sortAt - left.sortAt)
     .slice(0, 3)
     .map(({ sortAt: _sortAt, ...receipt }) => receipt);
+
+  return {
+    latestReceipts,
+    ...(latestReceipts[0] ? { latestReceipt: latestReceipts[0] } : {}),
+    receiptHealth: {
+      status:
+        versionMismatchCount > 0 ||
+          invalidReceiptCount > 0 ||
+          unreadableReceiptCount > 0 ||
+          latestReceipts.length === 0
+          ? "degraded"
+          : "ok",
+      contractVersion: WAVE1_RELEASE_RECEIPT_VERSION,
+      validReceiptCount: receipts.length,
+      versionMismatchCount,
+      invalidReceiptCount,
+      unreadableReceiptCount,
+      missingLatestReceipt: latestReceipts.length === 0,
+    },
+  };
 }
 
 export async function readReleaseOperatorEvidence(
@@ -221,12 +276,22 @@ export async function readReleaseOperatorEvidence(
   const currentMetadata = current?.metadataPath
     ? await readReleaseMetadata(path.join(resolvedRoot, current.metadataPath))
     : undefined;
-  const latestReceipts = await readLatestReceipts(resolvedRoot, receiptsDir);
+  const { latestReceipts, latestReceipt, receiptHealth } = await readLatestReceipts(
+    resolvedRoot,
+    receiptsDir,
+  );
   const latestRollbackReceipt = latestReceipts.find(
     (receipt) => receipt.action === "rollback",
   );
 
-  if (!current && !previous && latestReceipts.length === 0) {
+  if (
+    !current &&
+    !previous &&
+    latestReceipts.length === 0 &&
+    receiptHealth.versionMismatchCount === 0 &&
+    receiptHealth.invalidReceiptCount === 0 &&
+    receiptHealth.unreadableReceiptCount === 0
+  ) {
     return undefined;
   }
 
@@ -240,6 +305,8 @@ export async function readReleaseOperatorEvidence(
       current && previous && currentMetadata?.rollbackTarget,
     ),
     receiptsDir: normalizeRelativePath(resolvedRoot, receiptsDir),
+    receiptHealth,
+    ...(latestReceipt ? { latestReceipt } : {}),
     ...(latestRollbackReceipt ? { latestRollbackReceipt } : {}),
     latestReceipts,
   };


### PR DESCRIPTION
## Summary

- extend release-state evidence with a non-fatal `receiptHealth` summary for valid, unreadable, invalid, and version-mismatched release receipts
- surface the latest valid receipt id/action/status plus receipt contract-version health in `status`, `status --proof-text`, `status --proof-json`, and `logs`
- treat invalid or mismatched receipt files as degraded operator evidence instead of crashing or silently trusting them
- add deterministic operator-evidence coverage that injects a mismatched-version receipt and an unreadable receipt, then verifies the degraded summary still preserves current/previous release evidence and latest valid receipt output

## Verification

- `node scripts\test-wave1-operator-evidence-deterministic.mjs`
- `pnpm run verify`

## Scope note

This lane is read/status surface hardening only. It does not change deploy-contract validation, release schemas, release receipt schemas, hosted control-plane behavior, preview hosting, domain automation, TLS automation, or multi-node orchestration.

## Why this slice

PRs `#23` and `#24` are both draft-gated and already occupy contract/schema territory. This slice keeps forward motion in parallel by hardening operator evidence surfaces without stepping into those schema lanes.