### PR TITLE
Lifeline: harden release replay evidence

### DIFF
--- a/docs/ops/lifeline-operator-surface.md
+++ b/docs/ops/lifeline-operator-surface.md
@@ -46,6 +46,7 @@ Useful signals:
 - Healthy state requires the supervisor, the managed child process, port ownership, and a successful health check.
 - The status output always reports the local healthcheck URL, last known status, log path, manifest path, restart policy, and crash-loop state.
 - When Wave 1 release state exists, `lifeline status` also reports the current release id, previous release id, current artifact ref, rollback target, rollback readiness, the latest rollback receipt when present, and recent release receipts.
+- `lifeline status` and `lifeline status --proof-text` also report `releaseReplay` so operators can see whether immutable release receipts still reconstruct the persisted current/previous pointers.
 - `lifeline status <app-name> --proof-text` gives a compact operator brief.
 - `lifeline status <app-name> --proof-gate` makes the proof brief fail closed.
 
@@ -57,6 +58,7 @@ Useful signals:
 - `- rollbackTarget.releaseId:` and `- receipt:` lines show the concrete rollback target and recent release receipts.
 - `- rollbackReady: yes` means Lifeline can see current, previous, and rollback-target release metadata.
 - `- latestRollbackReceipt:` proves a rollback rehearsal or rollback action has emitted release receipt evidence.
+- `- releaseReplay:` must stay `verified`; a `degraded` value means receipt history no longer reconstructs the persisted release pointers cleanly.
 - `blockedReason` or `- health: managed app process not running` means cutover should stop.
 
 ## Receipt contract

--- a/docs/qa.md
+++ b/docs/qa.md
@@ -1,0 +1,13 @@
+# QA
+
+This repo owns QA intent only.
+
+- Adapter manifests live under `qa/adapters/`.
+- Scenario manifests live under `qa/scenarios/`.
+- ATLAS root owns schemas, runners, artifact validation, reports, and promotion logic.
+
+Lifeline satisfies QA LLEL through deterministic command and contract evidence.
+
+- Required promotion evidence: `pnpm run verify`
+- Required preflight evidence: `pnpm run typecheck`
+- Visual and physical-device evidence are not part of the Lifeline v1 contract surface.

--- a/docs/runbooks/wave1-release-replay-verification.md
+++ b/docs/runbooks/wave1-release-replay-verification.md
@@ -18,6 +18,7 @@ Release pointer lineage must be reproducible from immutable receipt history, not
 ## Pattern
 
 - replay receipts in chronological order
+- reject malformed, duplicate-id, or wrong-version release receipts as degraded evidence instead of silently skipping them
 - apply successful `activate` and `rollback` mutations to a derived current/previous state
 - treat failed mutation receipts as evidence that pointers should not have moved
 - compare replayed lineage to persisted pointer files and flag mismatches as degraded operator evidence

--- a/docs/runbooks/wave1-release-replay-verification.md
+++ b/docs/runbooks/wave1-release-replay-verification.md
@@ -1,0 +1,41 @@
+# Wave 1 Release Replay Verification
+
+Use this runbook when operator evidence must prove that persisted Wave 1 release receipts still reconstruct the current and previous release pointers without relying on mutable in-memory state.
+
+## Goal
+
+Confirm that receipt history alone can replay the release lineage for one app:
+
+- latest successful activation determines the current release
+- the immediately prior promoted release becomes previous
+- failed activation and rollback receipts preserve the existing pointer lineage
+- pointer files can be checked against replayed lineage to detect drift or tampering
+
+## Rule
+
+Release pointer lineage must be reproducible from immutable receipt history, not only from the latest pointer files.
+
+## Pattern
+
+- replay receipts in chronological order
+- apply successful `activate` and `rollback` mutations to a derived current/previous state
+- treat failed mutation receipts as evidence that pointers should not have moved
+- compare replayed lineage to persisted pointer files and flag mismatches as degraded operator evidence
+
+## Verification
+
+Run:
+
+```bash
+node scripts/test-wave1-release-replay-deterministic.mjs
+```
+
+Then run the repo contract:
+
+```bash
+pnpm run verify
+```
+
+## Failure Mode
+
+If pointer files drift, are hand-edited, or become partially stale, status surfaces can appear coherent while the immutable receipt log tells a different story. Hermetic replay catches that mismatch before operators trust the wrong release lineage.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "verify": "pnpm typecheck && pnpm build && pnpm test:wave1-deploy-contract && pnpm test:wave1-release-mechanics && pnpm test:wave1-release-cli && pnpm test:wave1-operator-evidence && pnpm test:topology-manifest && pnpm test:privileged-execution-bridge && pnpm test:privileged-execution-repair && pnpm test:ui-proof-receipt",
+    "verify": "pnpm typecheck && pnpm build && pnpm test:wave1-deploy-contract && pnpm test:wave1-release-mechanics && pnpm test:wave1-release-cli && pnpm test:wave1-release-replay && pnpm test:wave1-operator-evidence && pnpm test:topology-manifest && pnpm test:privileged-execution-bridge && pnpm test:privileged-execution-repair && pnpm test:ui-proof-receipt",
     "check": "biome check .",
     "format": "biome format --write .",
     "validate:fitness": "node dist/cli.js validate examples/fitness-app.lifeline.yml",
@@ -65,6 +65,7 @@
     "test:wave1-release-mechanics": "node scripts/test-wave1-release-mechanics-deterministic.mjs",
     "test:wave1-release-cli": "node scripts/test-wave1-release-cli-deterministic.mjs",
     "test:wave1-operator-evidence": "node scripts/test-wave1-operator-evidence-deterministic.mjs",
+    "test:wave1-release-replay": "node scripts/test-wave1-release-replay-deterministic.mjs",
     "test:topology-manifest": "node scripts/test-topology-manifest-deterministic.mjs",
     "test:startup-deterministic": "node scripts/test-wave2-startup-deterministic.mjs",
     "test:startup-roundtrip": "node scripts/test-startup-roundtrip-windows-deterministic.mjs",

--- a/qa/adapters/lifeline.package.json
+++ b/qa/adapters/lifeline.package.json
@@ -1,0 +1,38 @@
+{
+  "contract_version": "atlas.qa.adapter.v1",
+  "adapter_id": "lifeline.package",
+  "repo_id": "lifeline",
+  "repo_path": "repos/fawxzzy-lifeline",
+  "framework": "service-or-package",
+  "lens_manifest_ref": "ops/atlas/qa/lenses/atlas-default-web.v1.json",
+  "commands": {
+    "typecheck": {
+      "command": "pnpm run typecheck"
+    },
+    "verify": {
+      "command": "pnpm run verify"
+    },
+    "qa_contract": {
+      "command": "pnpm run verify"
+    }
+  },
+  "lenses": [
+    {
+      "lens_id": "desktop.chromium.emulated",
+      "profile_id": "desktop.chromium",
+      "proof_kind": "emulated",
+      "evidence_kind": "emulated_browser",
+      "required_for": [
+        "evidence",
+        "promotion"
+      ],
+      "promotion_tier": "emulated_browser",
+      "fallback_behavior": "blocked",
+      "execution_mode": "repo_command",
+      "command_ref": "qa_contract"
+    }
+  ],
+  "supported_scenarios": [
+    "lifeline.contract-smoke"
+  ]
+}

--- a/qa/scenarios/lifeline.contract-smoke.json
+++ b/qa/scenarios/lifeline.contract-smoke.json
@@ -1,0 +1,66 @@
+{
+  "contract_version": "atlas.qa.scenario.v1",
+  "scenario_id": "lifeline.contract-smoke",
+  "title": "Lifeline package contract smoke",
+  "summary": "Repo-owned Lifeline QA intent for deterministic contract and verify evidence.",
+  "repo_id": "lifeline",
+  "repo_path": "repos/fawxzzy-lifeline",
+  "adapter_id": "lifeline.package",
+  "criticality": "high",
+  "tags": [
+    "lifeline",
+    "package",
+    "contract"
+  ],
+  "entrypoint": {
+    "path": "package:root"
+  },
+  "proof": {
+    "lens_manifest_ref": "ops/atlas/qa/lenses/atlas-default-web.v1.json",
+    "pr_lenses": [
+      "desktop.chromium.emulated"
+    ],
+    "certify_lenses": [],
+    "real_device_strategy": "manual_only"
+  },
+  "required_artifacts": [
+    {
+      "artifact_key": "execution",
+      "artifact_kind": "executable_report",
+      "step_id": "verify",
+      "required_lenses": [
+        "desktop.chromium.emulated"
+      ]
+    }
+  ],
+  "execution": {
+    "preflight_command_sequence": [
+      "typecheck"
+    ],
+    "pr_command_sequence": [
+      "verify"
+    ],
+    "certify_command_sequence": []
+  },
+  "test_evidence": [
+    {
+      "evidence_id": "lifeline.verify",
+      "kind": "contract",
+      "runner": "custom",
+      "command_ref": "verify",
+      "required_for": [
+        "promotion"
+      ]
+    }
+  ],
+  "promotion": {
+    "require_executable_truth": true,
+    "require_pr_artifacts": true,
+    "require_real_device_on": "never",
+    "allow_manual_certification": false,
+    "max_flaky_lenses": 0,
+    "blocking_artifact_kinds": [
+      "executable_report"
+    ]
+  }
+}

--- a/scripts/test-wave1-operator-evidence-deterministic.mjs
+++ b/scripts/test-wave1-operator-evidence-deterministic.mjs
@@ -232,6 +232,7 @@ try {
   assertIncludes(statusResult.stdout, "- rollbackTarget.artifactRef: docker://runtime-smoke-app:release-a", "status: missing rollback artifact ref");
   assertIncludes(statusResult.stdout, "- rollbackTarget.strategy: restore", "status: missing rollback strategy");
   assertIncludes(statusResult.stdout, "- rollbackReady: yes", "status: missing rollback readiness");
+  assertIncludes(statusResult.stdout, "- releaseReplay: verified (6 receipts applied)", "status: missing release replay verification");
   assertIncludes(statusResult.stdout, "- latestRollbackReceipt: rollback succeeded release-runtime-smoke-app-a", "status: missing rollback rehearsal receipt");
   assertIncludes(statusResult.stdout, "- receiptsDir: .lifeline/releases/runtime-smoke-app/receipts", "status: missing receipts dir");
   assertIncludes(statusResult.stdout, "- receipt: activate succeeded release-runtime-smoke-app-b", "status: missing receipt summary");
@@ -249,7 +250,45 @@ try {
   assertIncludes(proofResult.stdout, "- previousReleaseId: release-runtime-smoke-app-a", "proof-text: missing previous release id");
   assertIncludes(proofResult.stdout, "- rollbackTarget: release-runtime-smoke-app-a (restore)", "proof-text: missing rollback target");
   assertIncludes(proofResult.stdout, "- rollbackReady: yes", "proof-text: missing rollback readiness");
+  assertIncludes(proofResult.stdout, "- releaseReplay: verified (6 receipts applied)", "proof-text: missing release replay verification");
   assertIncludes(proofResult.stdout, "- latestRollbackReceipt: rollback succeeded release-runtime-smoke-app-a", "proof-text: missing rollback rehearsal receipt");
+
+  const tamperedCurrentPointerPath = path.join(
+    tempWorkspace,
+    ".lifeline",
+    "releases",
+    appName,
+    "current.json",
+  );
+  const tamperedCurrent = JSON.parse(await readFile(tamperedCurrentPointerPath, "utf8"));
+  tamperedCurrent.releaseId = "tampered-release";
+  await writeFile(
+    tamperedCurrentPointerPath,
+    `${JSON.stringify(tamperedCurrent, null, 2)}\n`,
+    "utf8",
+  );
+
+  const degradedProofResult = await runCli(["status", appName, "--proof-text"], {
+    cwd: tempWorkspace,
+    allowFailure: true,
+  });
+  assert.equal(
+    degradedProofResult.code,
+    0,
+    `degraded proof-text: expected exit 0, got ${degradedProofResult.code}\n${degradedProofResult.stdout}\n${degradedProofResult.stderr}`,
+  );
+  assertIncludes(degradedProofResult.stdout, "- releaseReplay: degraded (6 receipts applied)", "proof-text: missing degraded release replay state");
+  assertIncludes(
+    degradedProofResult.stdout,
+    "- releaseReplayIssues: current pointer mismatch: persisted=tampered-release replayed=release-runtime-smoke-app-b",
+    "proof-text: missing degraded replay issue detail",
+  );
+  tamperedCurrent.releaseId = releaseB.releaseId;
+  await writeFile(
+    tamperedCurrentPointerPath,
+    `${JSON.stringify(tamperedCurrent, null, 2)}\n`,
+    "utf8",
+  );
 
   const logsResult = await runCli(["logs", appName, "20"], {
     cwd: tempWorkspace,

--- a/scripts/test-wave1-release-replay-deterministic.mjs
+++ b/scripts/test-wave1-release-replay-deterministic.mjs
@@ -1,0 +1,256 @@
+import { strict as assert } from "node:assert";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+import { ensureBuilt } from "./lib/ensure-built.mjs";
+import {
+  activateWave1Release,
+  persistWave1Release,
+  rollbackWave1Release,
+} from "../control-plane/wave1-release-engine.mjs";
+
+function createManifest({
+  appName,
+  artifactRef,
+  rollbackReleaseId,
+  rollbackArtifactRef,
+  migrationHooks,
+}) {
+  return {
+    contractVersion: "atlas.lifeline.deploy-contract.v1",
+    appName,
+    artifactRef,
+    route: {
+      domain: `${appName}.lifeline.internal`,
+      path: "/",
+    },
+    envRefs: [],
+    healthcheckPath: "/healthz",
+    migrationHooks: {
+      preDeploy: ["pnpm verify"],
+      postDeploy: ["pnpm smoke:release"],
+      rollback: ["pnpm rollback:release"],
+      ...(migrationHooks ?? {}),
+    },
+    rollbackTarget: {
+      releaseId: rollbackReleaseId,
+      artifactRef: rollbackArtifactRef,
+      strategy: "restore",
+    },
+  };
+}
+
+function quoteShellArg(value) {
+  return `"${String(value).replace(/"/g, '\\"')}"`;
+}
+
+function buildHookCommand(scriptPath, phase, mode, logPath) {
+  return [process.execPath, scriptPath, phase, mode, logPath]
+    .map(quoteShellArg)
+    .join(" ");
+}
+
+async function writeHookRunner(scriptPath) {
+  await writeFile(
+    scriptPath,
+    [
+      "import { appendFile } from 'node:fs/promises';",
+      "const [phase, mode, logPath] = process.argv.slice(2);",
+      "await appendFile(logPath, `${phase}\\n`, 'utf8');",
+      "if (mode === 'fail') {",
+      "  process.exit(1);",
+      "}",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+await ensureBuilt();
+const { replayWave1ReleaseReceipts, verifyWave1ReleaseReplay } = await import(
+  "../dist/core/release-replay.js"
+);
+
+const tempRoot = await mkdtemp(
+  path.join(os.tmpdir(), "lifeline-release-replay-"),
+);
+
+try {
+  const appName = "lifeline-pilot";
+  const hookRunnerPath = path.join(tempRoot, "hook-runner.mjs");
+  const hookLogPath = path.join(tempRoot, "hook-log.txt");
+  await writeHookRunner(hookRunnerPath);
+
+  const successHooks = {
+    preActivate: [
+      buildHookCommand(hookRunnerPath, "preActivate", "success", hookLogPath),
+    ],
+    postActivate: [
+      buildHookCommand(hookRunnerPath, "postActivate", "success", hookLogPath),
+    ],
+    preRollback: [
+      buildHookCommand(hookRunnerPath, "preRollback", "success", hookLogPath),
+    ],
+  };
+  const failingPreActivateHooks = {
+    ...successHooks,
+    preActivate: [
+      buildHookCommand(hookRunnerPath, "preActivate", "fail", hookLogPath),
+    ],
+  };
+  const failingPreRollbackHooks = {
+    ...successHooks,
+    preRollback: [
+      buildHookCommand(hookRunnerPath, "preRollback", "fail", hookLogPath),
+    ],
+  };
+
+  const releaseA = await persistWave1Release(
+    createManifest({
+      appName,
+      artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      rollbackReleaseId: "bootstrap-release",
+      rollbackArtifactRef:
+        "ghcr.io/fawxzzy/lifeline-pilot@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      migrationHooks: successHooks,
+    }),
+    {
+      rootDir: tempRoot,
+      releaseId: "release-20260511-0001",
+      createdAt: "2026-05-11T14:00:00.000Z",
+      receiptAt: "2026-05-11T14:00:00.000Z",
+    },
+  );
+
+  await activateWave1Release(tempRoot, appName, releaseA.releaseId, {
+    receiptAt: "2026-05-11T14:05:00.000Z",
+    checkHealth: async () => ({ ok: true, status: 200 }),
+  });
+
+  let verification = await verifyWave1ReleaseReplay(appName, tempRoot);
+  assert.equal(verification.ok, true, verification.issues.join("\n"));
+  assert.equal(verification.replayedCurrent?.releaseId, releaseA.releaseId);
+  assert.equal(verification.replayedPrevious, undefined);
+
+  const releaseB = await persistWave1Release(
+    createManifest({
+      appName,
+      artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      rollbackReleaseId: releaseA.releaseId,
+      rollbackArtifactRef: releaseA.releaseMetadata.artifactRef,
+      migrationHooks: successHooks,
+    }),
+    {
+      rootDir: tempRoot,
+      releaseId: "release-20260511-0002",
+      createdAt: "2026-05-11T14:10:00.000Z",
+      receiptAt: "2026-05-11T14:10:00.000Z",
+    },
+  );
+
+  await activateWave1Release(tempRoot, appName, releaseB.releaseId, {
+    receiptAt: "2026-05-11T14:15:00.000Z",
+    checkHealth: async () => ({ ok: true, status: 200 }),
+  });
+
+  verification = await verifyWave1ReleaseReplay(appName, tempRoot);
+  assert.equal(verification.ok, true, verification.issues.join("\n"));
+  assert.equal(verification.replayedCurrent?.releaseId, releaseB.releaseId);
+  assert.equal(verification.replayedPrevious?.releaseId, releaseA.releaseId);
+
+  const releaseC = await persistWave1Release(
+    createManifest({
+      appName,
+      artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      rollbackReleaseId: releaseB.releaseId,
+      rollbackArtifactRef: releaseB.releaseMetadata.artifactRef,
+      migrationHooks: failingPreActivateHooks,
+    }),
+    {
+      rootDir: tempRoot,
+      releaseId: "release-20260511-0003",
+      createdAt: "2026-05-11T14:20:00.000Z",
+      receiptAt: "2026-05-11T14:20:00.000Z",
+    },
+  );
+
+  await activateWave1Release(tempRoot, appName, releaseC.releaseId, {
+    receiptAt: "2026-05-11T14:25:00.000Z",
+    checkHealth: async () => ({ ok: true, status: 200 }),
+  });
+
+  verification = await verifyWave1ReleaseReplay(appName, tempRoot);
+  assert.equal(verification.ok, true, verification.issues.join("\n"));
+  assert.equal(verification.replayedCurrent?.releaseId, releaseB.releaseId);
+  assert.equal(verification.replayedPrevious?.releaseId, releaseA.releaseId);
+
+  await rollbackWave1Release(tempRoot, appName, {
+    receiptAt: "2026-05-11T14:30:00.000Z",
+    checkHealth: async () => ({ ok: true, status: 200 }),
+  });
+
+  verification = await verifyWave1ReleaseReplay(appName, tempRoot);
+  assert.equal(verification.ok, true, verification.issues.join("\n"));
+  assert.equal(verification.replayedCurrent?.releaseId, releaseA.releaseId);
+  assert.equal(verification.replayedPrevious?.releaseId, releaseB.releaseId);
+
+  const releaseD = await persistWave1Release(
+    createManifest({
+      appName,
+      artifactRef: "ghcr.io/fawxzzy/lifeline-pilot@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      rollbackReleaseId: releaseA.releaseId,
+      rollbackArtifactRef: releaseA.releaseMetadata.artifactRef,
+      migrationHooks: failingPreRollbackHooks,
+    }),
+    {
+      rootDir: tempRoot,
+      releaseId: "release-20260511-0004",
+      createdAt: "2026-05-11T14:35:00.000Z",
+      receiptAt: "2026-05-11T14:35:00.000Z",
+    },
+  );
+
+  await activateWave1Release(tempRoot, appName, releaseD.releaseId, {
+    receiptAt: "2026-05-11T14:40:00.000Z",
+    checkHealth: async () => ({ ok: true, status: 200 }),
+  });
+
+  await rollbackWave1Release(tempRoot, appName, {
+    receiptAt: "2026-05-11T14:45:00.000Z",
+    checkHealth: async () => ({ ok: true, status: 200 }),
+  });
+
+  verification = await verifyWave1ReleaseReplay(appName, tempRoot);
+  assert.equal(verification.ok, true, verification.issues.join("\n"));
+  assert.equal(verification.replayedCurrent?.releaseId, releaseA.releaseId);
+  assert.equal(verification.replayedPrevious?.releaseId, releaseD.releaseId);
+  assert.equal(verification.appliedReceipts.length, 10);
+
+  const currentPointerPath = path.join(
+    tempRoot,
+    ".lifeline",
+    "releases",
+    appName,
+    "current.json",
+  );
+  const persistedCurrent = JSON.parse(await readFile(currentPointerPath, "utf8"));
+  persistedCurrent.releaseId = "tampered-release";
+  await writeFile(currentPointerPath, `${JSON.stringify(persistedCurrent, null, 2)}\n`, "utf8");
+
+  const replayOnly = await replayWave1ReleaseReceipts(appName, tempRoot);
+  assert.equal(replayOnly.replayedCurrent?.releaseId, releaseA.releaseId);
+  assert.equal(replayOnly.replayedPrevious?.releaseId, releaseD.releaseId);
+  assert.deepEqual(replayOnly.issues, []);
+
+  const tamperedVerification = await verifyWave1ReleaseReplay(appName, tempRoot);
+  assert.equal(tamperedVerification.ok, false);
+  assert.match(
+    tamperedVerification.issues.join("\n"),
+    /current pointer mismatch: persisted=tampered-release replayed=release-20260511-0001/,
+  );
+
+  console.log("Wave 1 release replay deterministic verification passed.");
+} finally {
+  await rm(tempRoot, { recursive: true, force: true });
+}

--- a/scripts/test-wave1-release-replay-deterministic.mjs
+++ b/scripts/test-wave1-release-replay-deterministic.mjs
@@ -243,6 +243,77 @@ try {
   assert.equal(replayOnly.replayedPrevious?.releaseId, releaseD.releaseId);
   assert.deepEqual(replayOnly.issues, []);
 
+  const receiptsDir = path.join(
+    tempRoot,
+    ".lifeline",
+    "releases",
+    appName,
+    "receipts",
+  );
+  const malformedReceiptPath = path.join(receiptsDir, "malformed.json");
+  await writeFile(malformedReceiptPath, "{not-json}\n", "utf8");
+
+  const malformedReplay = await replayWave1ReleaseReceipts(appName, tempRoot);
+  assert.equal(malformedReplay.replayedCurrent?.releaseId, releaseA.releaseId);
+  assert.equal(malformedReplay.replayedPrevious?.releaseId, releaseD.releaseId);
+  assert.match(
+    malformedReplay.issues.join("\n"),
+    /malformed\.json is not valid JSON/,
+  );
+  await rm(malformedReceiptPath, { force: true });
+
+  const wrongVersionReceiptPath = path.join(receiptsDir, "wrong-version.json");
+  await writeFile(
+    wrongVersionReceiptPath,
+    `${JSON.stringify(
+      {
+        contractVersion: "atlas.lifeline.release-receipt.v0",
+        receiptId: "wrong-version-receipt",
+        action: "activate",
+        status: "succeeded",
+        releaseId: releaseD.releaseId,
+        previousReleaseId: releaseA.releaseId,
+        createdAt: "2026-05-11T14:50:00.000Z",
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+
+  const wrongVersionReplay = await replayWave1ReleaseReceipts(appName, tempRoot);
+  assert.match(
+    wrongVersionReplay.issues.join("\n"),
+    /wrong-version\.json has unsupported contractVersion atlas\.lifeline\.release-receipt\.v0/,
+  );
+  await rm(wrongVersionReceiptPath, { force: true });
+
+  const duplicateReceiptPath = path.join(receiptsDir, "duplicate-id.json");
+  await writeFile(
+    duplicateReceiptPath,
+    `${JSON.stringify(
+      {
+        contractVersion: "atlas.lifeline.release-receipt.v1",
+        receiptId: releaseD.receipt.receiptId,
+        action: "activate",
+        status: "succeeded",
+        releaseId: releaseD.releaseId,
+        previousReleaseId: releaseA.releaseId,
+        createdAt: "2026-05-11T14:55:00.000Z",
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+
+  const duplicateReplay = await replayWave1ReleaseReceipts(appName, tempRoot);
+  assert.match(
+    duplicateReplay.issues.join("\n"),
+    /duplicate release receipt id .*duplicate-id\.json/,
+  );
+  await rm(duplicateReceiptPath, { force: true });
+
   const tamperedVerification = await verifyWave1ReleaseReplay(appName, tempRoot);
   assert.equal(tamperedVerification.ok, false);
   assert.match(

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -126,6 +126,14 @@ function serializeProofPayload(snapshot: RuntimeSnapshot): {
       release_id: string;
       path: string;
     };
+    replay_verification: {
+      ok: boolean;
+      issue_count: number;
+      issues: string[];
+      applied_receipts: number;
+      replayed_current_release_id?: string;
+      replayed_previous_release_id?: string;
+    };
     receipts_dir: string;
     latest_receipts: Array<{
       receipt_id: string;
@@ -163,6 +171,24 @@ function serializeProofPayload(snapshot: RuntimeSnapshot): {
             }
           : {}),
         rollback_ready: snapshot.release.rollbackReady,
+        replay_verification: {
+          ok: snapshot.release.replayVerification.ok,
+          issue_count: snapshot.release.replayVerification.issueCount,
+          issues: snapshot.release.replayVerification.issues,
+          applied_receipts: snapshot.release.replayVerification.appliedReceipts,
+          ...(snapshot.release.replayVerification.replayedCurrentReleaseId
+            ? {
+                replayed_current_release_id:
+                  snapshot.release.replayVerification.replayedCurrentReleaseId,
+              }
+            : {}),
+          ...(snapshot.release.replayVerification.replayedPreviousReleaseId
+            ? {
+                replayed_previous_release_id:
+                  snapshot.release.replayVerification.replayedPreviousReleaseId,
+              }
+            : {}),
+        },
         receipts_dir: snapshot.release.receiptsDir,
         latest_receipts: snapshot.release.latestReceipts.map((receipt) => ({
           receipt_id: receipt.receiptId,
@@ -247,11 +273,23 @@ function printProofText(payload: ReturnType<typeof serializeProofPayload>): void
   }
   if (payload.release) {
     console.log(`- rollbackReady: ${payload.release.rollback_ready ? "yes" : "no"}`);
+    console.log(
+      `- releaseReplay: ${payload.release.replay_verification.ok ? "verified" : "degraded"} (${payload.release.replay_verification.applied_receipts} receipts applied)`,
+    );
   }
   if (payload.release?.latest_rollback_receipt) {
     const receipt = payload.release.latest_rollback_receipt;
     console.log(
       `- latestRollbackReceipt: ${receipt.action} ${receipt.status} ${receipt.release_id} (${receipt.path})`,
+    );
+  }
+  if (
+    payload.release &&
+    !payload.release.replay_verification.ok &&
+    payload.release.replay_verification.issues.length > 0
+  ) {
+    console.log(
+      `- releaseReplayIssues: ${payload.release.replay_verification.issues.join("; ")}`,
     );
   }
 }
@@ -410,10 +448,22 @@ export async function runStatusCommand(
   }
   if (releaseEvidence) {
     console.log(`- rollbackReady: ${releaseEvidence.rollbackReady ? "yes" : "no"}`);
+    console.log(
+      `- releaseReplay: ${releaseEvidence.replayVerification.ok ? "verified" : "degraded"} (${releaseEvidence.replayVerification.appliedReceipts} receipts applied)`,
+    );
   }
   if (releaseEvidence?.latestRollbackReceipt) {
     console.log(
       `- latestRollbackReceipt: ${releaseEvidence.latestRollbackReceipt.action} ${releaseEvidence.latestRollbackReceipt.status} ${releaseEvidence.latestRollbackReceipt.releaseId} (${releaseEvidence.latestRollbackReceipt.path})`,
+    );
+  }
+  if (
+    releaseEvidence &&
+    !releaseEvidence.replayVerification.ok &&
+    releaseEvidence.replayVerification.issues.length > 0
+  ) {
+    console.log(
+      `- releaseReplayIssues: ${releaseEvidence.replayVerification.issues.join("; ")}`,
     );
   }
   if (releaseEvidence?.latestReceipts.length) {

--- a/src/core/release-replay.ts
+++ b/src/core/release-replay.ts
@@ -1,6 +1,9 @@
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
+const WAVE1_RELEASE_RECEIPT_VERSION =
+  "atlas.lifeline.release-receipt.v1";
+
 export interface ReleaseReplayPointer {
   releaseId: string;
   updatedAt: string;
@@ -93,7 +96,7 @@ async function readReplayPointer(
 async function readReplayReceipts(
   rootDir: string,
   appName: string,
-): Promise<ReleaseReplayReceipt[]> {
+): Promise<{ receipts: ReleaseReplayReceipt[]; issues: string[] }> {
   const receiptsDir = path.join(
     rootDir,
     ".lifeline",
@@ -103,6 +106,8 @@ async function readReplayReceipts(
   );
   const entries = (await readdir(receiptsDir).catch(() => [])) as string[];
   const receipts: Array<ReleaseReplayReceipt & { sortKey: string }> = [];
+  const issues: string[] = [];
+  const seenReceiptIds = new Map<string, string>();
 
   for (const entry of entries) {
     if (!entry.endsWith(".json")) {
@@ -110,17 +115,49 @@ async function readReplayReceipts(
     }
 
     const receiptPath = path.join(receiptsDir, entry);
-    const parsed = await readJsonIfPresent(receiptPath);
+    const relativeReceiptPath = normalizeRelativePath(rootDir, receiptPath);
+    const raw = await readFile(receiptPath, "utf8").catch(() => "");
+    if (!raw) {
+      issues.push(`release receipt ${relativeReceiptPath} is unreadable or empty`);
+      continue;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw) as unknown;
+    } catch {
+      issues.push(`release receipt ${relativeReceiptPath} is not valid JSON`);
+      continue;
+    }
+
     if (
       !isRecord(parsed) ||
+      !isNonEmptyString(parsed.contractVersion) ||
       !isNonEmptyString(parsed.receiptId) ||
       !isNonEmptyString(parsed.action) ||
       !isNonEmptyString(parsed.status) ||
       !isNonEmptyString(parsed.releaseId) ||
       !isNonEmptyString(parsed.createdAt)
     ) {
+      issues.push(`release receipt ${relativeReceiptPath} does not match the Wave 1 receipt contract`);
       continue;
     }
+
+    if (parsed.contractVersion !== WAVE1_RELEASE_RECEIPT_VERSION) {
+      issues.push(
+        `release receipt ${relativeReceiptPath} has unsupported contractVersion ${parsed.contractVersion}`,
+      );
+      continue;
+    }
+
+    const priorPath = seenReceiptIds.get(parsed.receiptId);
+    if (priorPath) {
+      issues.push(
+        `duplicate release receipt id ${parsed.receiptId} in ${priorPath} and ${relativeReceiptPath}`,
+      );
+      continue;
+    }
+    seenReceiptIds.set(parsed.receiptId, relativeReceiptPath);
 
     receipts.push({
       receiptId: parsed.receiptId,
@@ -137,14 +174,17 @@ async function readReplayReceipts(
       ...(isNonEmptyString(parsed.preservedPreviousReleaseId)
         ? { preservedPreviousReleaseId: parsed.preservedPreviousReleaseId }
         : {}),
-      path: normalizeRelativePath(rootDir, receiptPath),
+      path: relativeReceiptPath,
       sortKey: `${parsed.createdAt}-${entry}`,
     });
   }
 
-  return receipts
-    .sort((left, right) => left.sortKey.localeCompare(right.sortKey))
-    .map(({ sortKey: _sortKey, ...receipt }) => receipt);
+  return {
+    receipts: receipts
+      .sort((left, right) => left.sortKey.localeCompare(right.sortKey))
+      .map(({ sortKey: _sortKey, ...receipt }) => receipt),
+    issues,
+  };
 }
 
 function pointerIdsMatch(
@@ -260,8 +300,7 @@ export async function replayWave1ReleaseReceipts(
     appName,
     "receipts",
   );
-  const receipts = await readReplayReceipts(resolvedRoot, appName);
-  const issues: string[] = [];
+  const { receipts, issues } = await readReplayReceipts(resolvedRoot, appName);
   let state: ReleaseReplayState = {};
 
   for (const receipt of receipts) {

--- a/src/core/release-replay.ts
+++ b/src/core/release-replay.ts
@@ -1,0 +1,346 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+export interface ReleaseReplayPointer {
+  releaseId: string;
+  updatedAt: string;
+  reason: "activation" | "rollback";
+}
+
+export interface ReleaseReplayReceipt {
+  receiptId: string;
+  action: string;
+  status: string;
+  releaseId: string;
+  createdAt: string;
+  previousReleaseId?: string;
+  preservedCurrentReleaseId?: string;
+  preservedPreviousReleaseId?: string;
+  path: string;
+}
+
+export interface ReleaseReplayResult {
+  receiptsDir: string;
+  replayedCurrent?: ReleaseReplayPointer;
+  replayedPrevious?: ReleaseReplayPointer;
+  appliedReceipts: ReleaseReplayReceipt[];
+  issues: string[];
+}
+
+export interface ReleaseReplayVerificationResult extends ReleaseReplayResult {
+  ok: boolean;
+  persistedCurrent?: ReleaseReplayPointer;
+  persistedPrevious?: ReleaseReplayPointer;
+}
+
+interface ReleaseReplayState {
+  current?: ReleaseReplayPointer;
+  previous?: ReleaseReplayPointer;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function normalizeRelativePath(rootDir: string, filePath: string): string {
+  return path.relative(rootDir, filePath).replace(/\\/g, "/");
+}
+
+async function readJsonIfPresent(filePath: string): Promise<unknown | undefined> {
+  const raw = await readFile(filePath, "utf8").catch(() => "");
+  if (!raw) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+async function readReplayPointer(
+  filePath: string,
+): Promise<ReleaseReplayPointer | undefined> {
+  const parsed = await readJsonIfPresent(filePath);
+  if (!isRecord(parsed)) {
+    return undefined;
+  }
+
+  if (
+    !isNonEmptyString(parsed.releaseId) ||
+    !isNonEmptyString(parsed.updatedAt) ||
+    !isNonEmptyString(parsed.reason)
+  ) {
+    return undefined;
+  }
+
+  if (parsed.reason !== "activation" && parsed.reason !== "rollback") {
+    return undefined;
+  }
+
+  return {
+    releaseId: parsed.releaseId,
+    updatedAt: parsed.updatedAt,
+    reason: parsed.reason,
+  };
+}
+
+async function readReplayReceipts(
+  rootDir: string,
+  appName: string,
+): Promise<ReleaseReplayReceipt[]> {
+  const receiptsDir = path.join(
+    rootDir,
+    ".lifeline",
+    "releases",
+    appName,
+    "receipts",
+  );
+  const entries = (await readdir(receiptsDir).catch(() => [])) as string[];
+  const receipts: Array<ReleaseReplayReceipt & { sortKey: string }> = [];
+
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) {
+      continue;
+    }
+
+    const receiptPath = path.join(receiptsDir, entry);
+    const parsed = await readJsonIfPresent(receiptPath);
+    if (
+      !isRecord(parsed) ||
+      !isNonEmptyString(parsed.receiptId) ||
+      !isNonEmptyString(parsed.action) ||
+      !isNonEmptyString(parsed.status) ||
+      !isNonEmptyString(parsed.releaseId) ||
+      !isNonEmptyString(parsed.createdAt)
+    ) {
+      continue;
+    }
+
+    receipts.push({
+      receiptId: parsed.receiptId,
+      action: parsed.action,
+      status: parsed.status,
+      releaseId: parsed.releaseId,
+      createdAt: parsed.createdAt,
+      ...(isNonEmptyString(parsed.previousReleaseId)
+        ? { previousReleaseId: parsed.previousReleaseId }
+        : {}),
+      ...(isNonEmptyString(parsed.preservedCurrentReleaseId)
+        ? { preservedCurrentReleaseId: parsed.preservedCurrentReleaseId }
+        : {}),
+      ...(isNonEmptyString(parsed.preservedPreviousReleaseId)
+        ? { preservedPreviousReleaseId: parsed.preservedPreviousReleaseId }
+        : {}),
+      path: normalizeRelativePath(rootDir, receiptPath),
+      sortKey: `${parsed.createdAt}-${entry}`,
+    });
+  }
+
+  return receipts
+    .sort((left, right) => left.sortKey.localeCompare(right.sortKey))
+    .map(({ sortKey: _sortKey, ...receipt }) => receipt);
+}
+
+function pointerIdsMatch(
+  actual: ReleaseReplayPointer | undefined,
+  expected: ReleaseReplayPointer | undefined,
+): boolean {
+  return actual?.releaseId === expected?.releaseId;
+}
+
+function applySucceededActivate(
+  state: ReleaseReplayState,
+  receipt: ReleaseReplayReceipt,
+  issues: string[],
+): ReleaseReplayState {
+  if (
+    state.current?.releaseId &&
+    receipt.previousReleaseId &&
+    state.current.releaseId !== receipt.previousReleaseId
+  ) {
+    issues.push(
+      `activate receipt ${receipt.receiptId} expected previousReleaseId ${state.current.releaseId} but found ${receipt.previousReleaseId}`,
+    );
+  }
+
+  const nextPreviousReleaseId =
+    receipt.previousReleaseId ??
+    (state.current?.releaseId && state.current.releaseId !== receipt.releaseId
+      ? state.current.releaseId
+      : state.previous?.releaseId);
+
+  return {
+    current: {
+      releaseId: receipt.releaseId,
+      updatedAt: receipt.createdAt,
+      reason: "activation",
+    },
+    ...(nextPreviousReleaseId
+      ? {
+          previous: {
+            releaseId: nextPreviousReleaseId,
+            updatedAt: receipt.createdAt,
+            reason: "activation",
+          },
+        }
+      : {}),
+  };
+}
+
+function applySucceededRollback(
+  receipt: ReleaseReplayReceipt,
+  issues: string[],
+): ReleaseReplayState {
+  if (!receipt.previousReleaseId) {
+    issues.push(
+      `rollback receipt ${receipt.receiptId} is missing previousReleaseId`,
+    );
+    return {
+      current: {
+        releaseId: receipt.releaseId,
+        updatedAt: receipt.createdAt,
+        reason: "rollback",
+      },
+    };
+  }
+
+  return {
+    current: {
+      releaseId: receipt.releaseId,
+      updatedAt: receipt.createdAt,
+      reason: "rollback",
+    },
+    previous: {
+      releaseId: receipt.previousReleaseId,
+      updatedAt: receipt.createdAt,
+      reason: "rollback",
+    },
+  };
+}
+
+function verifyFailedReceiptPreservesState(
+  state: ReleaseReplayState,
+  receipt: ReleaseReplayReceipt,
+  issues: string[],
+): void {
+  if (
+    receipt.preservedCurrentReleaseId &&
+    receipt.preservedCurrentReleaseId !== state.current?.releaseId
+  ) {
+    issues.push(
+      `${receipt.action} failed receipt ${receipt.receiptId} preservedCurrentReleaseId ${receipt.preservedCurrentReleaseId} does not match replayed current ${state.current?.releaseId ?? "<none>"}`,
+    );
+  }
+
+  if (
+    receipt.preservedPreviousReleaseId &&
+    receipt.preservedPreviousReleaseId !== state.previous?.releaseId
+  ) {
+    issues.push(
+      `${receipt.action} failed receipt ${receipt.receiptId} preservedPreviousReleaseId ${receipt.preservedPreviousReleaseId} does not match replayed previous ${state.previous?.releaseId ?? "<none>"}`,
+    );
+  }
+}
+
+export async function replayWave1ReleaseReceipts(
+  appName: string,
+  rootDir = process.cwd(),
+): Promise<ReleaseReplayResult> {
+  const resolvedRoot = path.resolve(rootDir);
+  const receiptsDir = path.join(
+    resolvedRoot,
+    ".lifeline",
+    "releases",
+    appName,
+    "receipts",
+  );
+  const receipts = await readReplayReceipts(resolvedRoot, appName);
+  const issues: string[] = [];
+  let state: ReleaseReplayState = {};
+
+  for (const receipt of receipts) {
+    if (receipt.action === "activate") {
+      if (receipt.status === "succeeded") {
+        state = applySucceededActivate(state, receipt, issues);
+        continue;
+      }
+
+      if (receipt.status === "failed") {
+        verifyFailedReceiptPreservesState(state, receipt, issues);
+        continue;
+      }
+    }
+
+    if (receipt.action === "rollback") {
+      if (receipt.status === "succeeded") {
+        state = applySucceededRollback(receipt, issues);
+        continue;
+      }
+
+      if (receipt.status === "failed") {
+        verifyFailedReceiptPreservesState(state, receipt, issues);
+        continue;
+      }
+    }
+  }
+
+  return {
+    receiptsDir: normalizeRelativePath(resolvedRoot, receiptsDir),
+    ...(state.current ? { replayedCurrent: state.current } : {}),
+    ...(state.previous ? { replayedPrevious: state.previous } : {}),
+    appliedReceipts: receipts,
+    issues,
+  };
+}
+
+export async function verifyWave1ReleaseReplay(
+  appName: string,
+  rootDir = process.cwd(),
+): Promise<ReleaseReplayVerificationResult> {
+  const resolvedRoot = path.resolve(rootDir);
+  const appReleaseRoot = path.join(
+    resolvedRoot,
+    ".lifeline",
+    "releases",
+    appName,
+  );
+  const [replayResult, persistedCurrent, persistedPrevious] = await Promise.all([
+    replayWave1ReleaseReceipts(appName, resolvedRoot),
+    readReplayPointer(path.join(appReleaseRoot, "current.json")),
+    readReplayPointer(path.join(appReleaseRoot, "previous.json")),
+  ]);
+  const issues = [...replayResult.issues];
+
+  if (!pointerIdsMatch(persistedCurrent, replayResult.replayedCurrent)) {
+    issues.push(
+      `current pointer mismatch: persisted=${persistedCurrent?.releaseId ?? "<none>"} replayed=${replayResult.replayedCurrent?.releaseId ?? "<none>"}`,
+    );
+  }
+
+  if (!pointerIdsMatch(persistedPrevious, replayResult.replayedPrevious)) {
+    issues.push(
+      `previous pointer mismatch: persisted=${persistedPrevious?.releaseId ?? "<none>"} replayed=${replayResult.replayedPrevious?.releaseId ?? "<none>"}`,
+    );
+  }
+
+  return {
+    ok: issues.length === 0,
+    receiptsDir: replayResult.receiptsDir,
+    ...(replayResult.replayedCurrent
+      ? { replayedCurrent: replayResult.replayedCurrent }
+      : {}),
+    ...(replayResult.replayedPrevious
+      ? { replayedPrevious: replayResult.replayedPrevious }
+      : {}),
+    ...(persistedCurrent ? { persistedCurrent } : {}),
+    ...(persistedPrevious ? { persistedPrevious } : {}),
+    appliedReceipts: replayResult.appliedReceipts,
+    issues,
+  };
+}

--- a/src/core/release-state.ts
+++ b/src/core/release-state.ts
@@ -1,6 +1,8 @@
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
+import { verifyWave1ReleaseReplay } from "./release-replay.js";
+
 export interface ReleasePointer {
   releaseId: string;
   updatedAt: string;
@@ -39,6 +41,14 @@ export interface ReleaseOperatorEvidence {
   rollbackReady: boolean;
   latestRollbackReceipt?: ReleaseReceiptSummary;
   latestReceipts: ReleaseReceiptSummary[];
+  replayVerification: {
+    ok: boolean;
+    issueCount: number;
+    issues: string[];
+    appliedReceipts: number;
+    replayedCurrentReleaseId?: string;
+    replayedPreviousReleaseId?: string;
+  };
 }
 
 interface ReleaseMetadataLike {
@@ -221,7 +231,10 @@ export async function readReleaseOperatorEvidence(
   const currentMetadata = current?.metadataPath
     ? await readReleaseMetadata(path.join(resolvedRoot, current.metadataPath))
     : undefined;
-  const latestReceipts = await readLatestReceipts(resolvedRoot, receiptsDir);
+  const [latestReceipts, replayVerification] = await Promise.all([
+    readLatestReceipts(resolvedRoot, receiptsDir),
+    verifyWave1ReleaseReplay(appName, resolvedRoot),
+  ]);
   const latestRollbackReceipt = latestReceipts.find(
     (receipt) => receipt.action === "rollback",
   );
@@ -242,5 +255,17 @@ export async function readReleaseOperatorEvidence(
     receiptsDir: normalizeRelativePath(resolvedRoot, receiptsDir),
     ...(latestRollbackReceipt ? { latestRollbackReceipt } : {}),
     latestReceipts,
+    replayVerification: {
+      ok: replayVerification.ok,
+      issueCount: replayVerification.issues.length,
+      issues: replayVerification.issues,
+      appliedReceipts: replayVerification.appliedReceipts.length,
+      ...(replayVerification.replayedCurrent
+        ? { replayedCurrentReleaseId: replayVerification.replayedCurrent.releaseId }
+        : {}),
+      ...(replayVerification.replayedPrevious
+        ? { replayedPreviousReleaseId: replayVerification.replayedPrevious.releaseId }
+        : {}),
+    },
   };
 }


### PR DESCRIPTION
## Summary
- validate Wave 1 release replay receipts instead of silently skipping malformed or wrong-version evidence
- surface release replay verification in status and proof-text operator output
- extend deterministic replay/operator evidence tests and update the operator runbook

## Verification
- `pnpm build`
- `node scripts/test-wave1-release-replay-deterministic.mjs`
- `node scripts/test-wave1-operator-evidence-deterministic.mjs`
- `pnpm run verify`