### PR TITLE
Lifeline: harden rollback confidence evidence

### DIFF
--- a/docs/ops/lifeline-operator-surface.md
+++ b/docs/ops/lifeline-operator-surface.md
@@ -47,6 +47,7 @@ Useful signals:
 - The status output always reports the local healthcheck URL, last known status, log path, manifest path, restart policy, and crash-loop state.
 - When Wave 1 release state exists, `lifeline status` also reports the current release id, previous release id, current artifact ref, rollback target, rollback readiness, the latest rollback receipt when present, and recent release receipts.
 - `lifeline status` and `lifeline status --proof-text` also report `releaseReplay` so operators can see whether immutable release receipts still reconstruct the persisted current/previous pointers.
+- `lifeline status`, `lifeline status --proof-text`, and `lifeline logs` also report `rollbackConfidence` so operators can distinguish "rollback target exists" from "rollback target still matches replayed previous-release evidence."
 - `lifeline status <app-name> --proof-text` gives a compact operator brief.
 - `lifeline status <app-name> --proof-gate` makes the proof brief fail closed.
 
@@ -56,9 +57,11 @@ Useful signals:
 - `- health: ok (200)` means the managed app is answering the healthcheck.
 - `- currentReleaseId:` and `- previousReleaseId:` identify the live and rollback-adjacent release lineage.
 - `- rollbackTarget.releaseId:` and `- receipt:` lines show the concrete rollback target and recent release receipts.
-- `- rollbackReady: yes` means Lifeline can see current, previous, and rollback-target release metadata.
+- `- rollbackReady: yes` means Lifeline can prove the persisted rollback target still matches replayed previous-release evidence.
+- `- rollbackConfidence:` reports whether rollback evidence is `ready` or `degraded`.
 - `- latestRollbackReceipt:` proves a rollback rehearsal or rollback action has emitted release receipt evidence.
 - `- releaseReplay:` must stay `verified`; a `degraded` value means receipt history no longer reconstructs the persisted release pointers cleanly.
+- `- rollbackConfidenceIssues:` explains stale, missing, or mismatched rollback metadata before an operator treats rollback as trustworthy.
 - `blockedReason` or `- health: managed app process not running` means cutover should stop.
 
 ## Receipt contract

--- a/docs/runbooks/wave1-release-pointer-operations.md
+++ b/docs/runbooks/wave1-release-pointer-operations.md
@@ -24,14 +24,15 @@ Destructive release pointer movement must be intentionally acknowledged at the C
 
 ## Rollback
 
-1. Confirm the current release has a valid previous release and rollback target.
-2. Re-run the rollback command with explicit confirmation:
+1. Confirm `lifeline status` reports both `rollbackReady: yes` and `rollbackConfidence: ready`.
+2. If `rollbackConfidence` is degraded, stop and fix the reported mismatch before moving the release pointers.
+3. Re-run the rollback command with explicit confirmation:
 
    ```bash
    lifeline release rollback <app-name> --yes
    ```
 
-3. Inspect the rollback receipt and operator evidence before treating the release as recovered.
+4. Inspect the rollback receipt and operator evidence before treating the release as recovered.
 
 ## Failure Mode
 

--- a/scripts/test-wave1-operator-evidence-deterministic.mjs
+++ b/scripts/test-wave1-operator-evidence-deterministic.mjs
@@ -232,6 +232,7 @@ try {
   assertIncludes(statusResult.stdout, "- rollbackTarget.artifactRef: docker://runtime-smoke-app:release-a", "status: missing rollback artifact ref");
   assertIncludes(statusResult.stdout, "- rollbackTarget.strategy: restore", "status: missing rollback strategy");
   assertIncludes(statusResult.stdout, "- rollbackReady: yes", "status: missing rollback readiness");
+  assertIncludes(statusResult.stdout, "- rollbackConfidence: ready", "status: missing healthy rollback confidence");
   assertIncludes(
     statusResult.stdout,
     "- receiptContractVersion: atlas.lifeline.release-receipt.v1",
@@ -261,6 +262,7 @@ try {
   assertIncludes(proofResult.stdout, "- previousReleaseId: release-runtime-smoke-app-a", "proof-text: missing previous release id");
   assertIncludes(proofResult.stdout, "- rollbackTarget: release-runtime-smoke-app-a (restore)", "proof-text: missing rollback target");
   assertIncludes(proofResult.stdout, "- rollbackReady: yes", "proof-text: missing rollback readiness");
+  assertIncludes(proofResult.stdout, "- rollbackConfidence: ready", "proof-text: missing healthy rollback confidence");
   assertIncludes(
     proofResult.stdout,
     "- receiptContractVersion: atlas.lifeline.release-receipt.v1",
@@ -274,6 +276,105 @@ try {
     "proof-text: missing latest receipt summary",
   );
   assertIncludes(proofResult.stdout, "- latestRollbackReceipt: rollback succeeded release-runtime-smoke-app-a", "proof-text: missing rollback rehearsal receipt");
+
+  const currentMetadataPath = path.join(
+    tempWorkspace,
+    ".lifeline",
+    "releases",
+    appName,
+    releaseB.releaseId,
+    "metadata.json",
+  );
+  const currentMetadata = JSON.parse(await readFile(currentMetadataPath, "utf8"));
+
+  currentMetadata.rollbackTarget.releaseId = "stale-release";
+  await writeFile(
+    currentMetadataPath,
+    `${JSON.stringify(currentMetadata, null, 2)}\n`,
+    "utf8",
+  );
+
+  const driftedStatusResult = await runCli(["status", appName], {
+    cwd: tempWorkspace,
+    allowFailure: true,
+  });
+  assert.equal(
+    driftedStatusResult.code,
+    0,
+    `drifted status: expected exit 0, got ${driftedStatusResult.code}\n${driftedStatusResult.stdout}\n${driftedStatusResult.stderr}`,
+  );
+  assertIncludes(driftedStatusResult.stdout, "- rollbackReady: no", "status: missing degraded rollback readiness");
+  assertIncludes(driftedStatusResult.stdout, "- rollbackConfidence: degraded", "status: missing degraded rollback confidence");
+  assertIncludes(
+    driftedStatusResult.stdout,
+    "rollback target releaseId stale-release does not match replayed previous release release-runtime-smoke-app-a",
+    "status: missing rollback release drift detail",
+  );
+
+  const driftedProofResult = await runCli(["status", appName, "--proof-text"], {
+    cwd: tempWorkspace,
+    allowFailure: true,
+  });
+  assert.equal(
+    driftedProofResult.code,
+    0,
+    `drifted proof-text: expected exit 0, got ${driftedProofResult.code}\n${driftedProofResult.stdout}\n${driftedProofResult.stderr}`,
+  );
+  assertIncludes(driftedProofResult.stdout, "- rollbackReady: no", "proof-text: missing degraded rollback readiness");
+  assertIncludes(driftedProofResult.stdout, "- rollbackConfidence: degraded", "proof-text: missing degraded rollback confidence");
+  assertIncludes(
+    driftedProofResult.stdout,
+    "rollback target releaseId stale-release does not match replayed previous release release-runtime-smoke-app-a",
+    "proof-text: missing rollback release drift detail",
+  );
+
+  const driftedLogsResult = await runCli(["logs", appName, "20"], {
+    cwd: tempWorkspace,
+    allowFailure: true,
+  });
+  assert.equal(
+    driftedLogsResult.code,
+    0,
+    `drifted logs: expected exit 0, got ${driftedLogsResult.code}\n${driftedLogsResult.stdout}\n${driftedLogsResult.stderr}`,
+  );
+  assertIncludes(driftedLogsResult.stdout, "- rollbackReady: no", "logs: missing degraded rollback readiness");
+  assertIncludes(driftedLogsResult.stdout, "- rollbackConfidence: degraded", "logs: missing degraded rollback confidence");
+  assertIncludes(
+    driftedLogsResult.stdout,
+    "rollback target releaseId stale-release does not match replayed previous release release-runtime-smoke-app-a",
+    "logs: missing rollback release drift detail",
+  );
+
+  currentMetadata.rollbackTarget.releaseId = releaseA.releaseId;
+  currentMetadata.rollbackTarget.artifactRef = "docker://runtime-smoke-app:stale-artifact";
+  await writeFile(
+    currentMetadataPath,
+    `${JSON.stringify(currentMetadata, null, 2)}\n`,
+    "utf8",
+  );
+
+  const staleArtifactStatusResult = await runCli(["status", appName], {
+    cwd: tempWorkspace,
+    allowFailure: true,
+  });
+  assert.equal(
+    staleArtifactStatusResult.code,
+    0,
+    `stale artifact status: expected exit 0, got ${staleArtifactStatusResult.code}\n${staleArtifactStatusResult.stdout}\n${staleArtifactStatusResult.stderr}`,
+  );
+  assertIncludes(staleArtifactStatusResult.stdout, "- rollbackConfidence: degraded", "status: missing stale artifact rollback confidence");
+  assertIncludes(
+    staleArtifactStatusResult.stdout,
+    "rollback target artifactRef docker://runtime-smoke-app:stale-artifact does not match replayed previous artifact docker://runtime-smoke-app:release-a",
+    "status: missing stale artifact rollback detail",
+  );
+
+  currentMetadata.rollbackTarget.artifactRef = releaseA.releaseMetadata.artifactRef;
+  await writeFile(
+    currentMetadataPath,
+    `${JSON.stringify(currentMetadata, null, 2)}\n`,
+    "utf8",
+  );
 
   const receiptsDir = path.join(
     tempWorkspace,
@@ -308,6 +409,11 @@ try {
     degradedStatusResult.code,
     0,
     `degraded status: expected exit 0, got ${degradedStatusResult.code}\n${degradedStatusResult.stdout}\n${degradedStatusResult.stderr}`,
+  );
+  assertIncludes(
+    degradedStatusResult.stdout,
+    "- rollbackConfidence: degraded",
+    "status: missing replay-driven degraded rollback confidence",
   );
   assertIncludes(
     degradedStatusResult.stdout,
@@ -351,6 +457,11 @@ try {
   );
   assertIncludes(
     degradedProofResult.stdout,
+    "- rollbackConfidence: degraded",
+    "proof-text: missing replay-driven degraded rollback confidence",
+  );
+  assertIncludes(
+    degradedProofResult.stdout,
     "- receiptHealth: degraded (versionMismatch=1, unreadable=1)",
     "proof-text: missing degraded receipt health summary",
   );
@@ -379,6 +490,7 @@ try {
   assertIncludes(logsResult.stdout, `=== lifeline logs ${appName} ===`, "logs: missing evidence header");
   assertIncludes(logsResult.stdout, "- currentReleaseId: release-runtime-smoke-app-b", "logs: missing current release id");
   assertIncludes(logsResult.stdout, "- previousReleaseId: release-runtime-smoke-app-a", "logs: missing previous release id");
+  assertIncludes(logsResult.stdout, "- rollbackConfidence: degraded", "logs: missing degraded rollback confidence");
   assertIncludes(
     logsResult.stdout,
     "- receiptContractVersion: atlas.lifeline.release-receipt.v1",
@@ -396,6 +508,65 @@ try {
   );
   assertIncludes(logsResult.stdout, "=== lifeline up ", "logs: missing startup header");
   assertIncludes(logsResult.stdout, `runtime-smoke-app listening on ${port}`, "logs: missing app startup line");
+
+  const noPreviousWorkspace = await mkdtemp(
+    path.join(os.tmpdir(), "lifeline-release-no-previous-workspace-"),
+  );
+  const noPreviousPort = await getFreePort();
+  const { tempRoot: noPreviousFixtureRoot, manifestPath: noPreviousManifestPath } =
+    await createDisposableFixtureRoot(noPreviousPort);
+
+  try {
+    const upNoPrevious = await runCli(["up", noPreviousManifestPath], {
+      cwd: noPreviousWorkspace,
+      allowFailure: true,
+    });
+    assert.equal(
+      upNoPrevious.code,
+      0,
+      `no-previous up: expected exit 0, got ${upNoPrevious.code}\n${upNoPrevious.stdout}\n${upNoPrevious.stderr}`,
+    );
+
+    const noPreviousRelease = await persistWave1Release(
+      createReleaseManifest({
+        artifactRef: "docker://runtime-smoke-app:no-previous",
+        rollbackReleaseId: "bootstrap-release",
+        rollbackArtifactRef: "docker://runtime-smoke-app:bootstrap",
+        port: noPreviousPort,
+      }),
+      {
+        rootDir: noPreviousWorkspace,
+        releaseId: "release-runtime-smoke-app-only",
+        createdAt: "2026-04-26T01:00:00.000Z",
+        receiptAt: "2026-04-26T01:00:00.000Z",
+      },
+    );
+    await activateWave1Release(noPreviousWorkspace, appName, noPreviousRelease.releaseId, {
+      receiptAt: "2026-04-26T01:01:00.000Z",
+      checkHealth: async () => ({ ok: true, status: 200 }),
+    });
+
+    const noPreviousStatus = await runCli(["status", appName], {
+      cwd: noPreviousWorkspace,
+      allowFailure: true,
+    });
+    assert.equal(
+      noPreviousStatus.code,
+      0,
+      `no-previous status: expected exit 0, got ${noPreviousStatus.code}\n${noPreviousStatus.stdout}\n${noPreviousStatus.stderr}`,
+    );
+    assertIncludes(noPreviousStatus.stdout, "- rollbackReady: no", "status: missing no-previous rollback readiness");
+    assertIncludes(noPreviousStatus.stdout, "- rollbackConfidence: degraded", "status: missing no-previous rollback confidence");
+    assertIncludes(
+      noPreviousStatus.stdout,
+      "replayed previous-release evidence is missing",
+      "status: missing no-previous evidence detail",
+    );
+  } finally {
+    await runCli(["down", appName], { cwd: noPreviousWorkspace, allowFailure: true }).catch(() => undefined);
+    await removeTreeWithRetries(noPreviousWorkspace);
+    await removeTreeWithRetries(noPreviousFixtureRoot);
+  }
 
   cleanupNeeded = false;
   console.log("Wave 1 operator evidence deterministic verification passed.");

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -28,6 +28,13 @@ export async function runLogsCommand(
     if (releaseEvidence.previous) {
       console.log(`- previousReleaseId: ${releaseEvidence.previous.releaseId}`);
     }
+    console.log(`- rollbackReady: ${releaseEvidence.rollbackReady ? "yes" : "no"}`);
+    console.log(`- rollbackConfidence: ${releaseEvidence.rollbackConfidence.status}`);
+    if (releaseEvidence.rollbackConfidence.issues.length > 0) {
+      console.log(
+        `- rollbackConfidenceIssues: ${releaseEvidence.rollbackConfidence.issues.join("; ")}`,
+      );
+    }
     console.log(`- receiptContractVersion: ${releaseEvidence.receiptHealth.contractVersion}`);
     if (releaseEvidence.latestReceipt) {
       console.log(

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -145,6 +145,12 @@ function serializeProofPayload(snapshot: RuntimeSnapshot): {
       note?: string;
     };
     rollback_ready: boolean;
+    rollback_confidence: {
+      status: string;
+      issues: string[];
+      replayed_previous_release_id?: string;
+      replayed_previous_artifact_ref?: string;
+    };
     receipt_health: {
       status: string;
       contract_version: string;
@@ -216,6 +222,22 @@ function serializeProofPayload(snapshot: RuntimeSnapshot): {
             }
           : {}),
         rollback_ready: snapshot.release.rollbackReady,
+        rollback_confidence: {
+          status: snapshot.release.rollbackConfidence.status,
+          issues: snapshot.release.rollbackConfidence.issues,
+          ...(snapshot.release.rollbackConfidence.replayedPreviousReleaseId
+            ? {
+                replayed_previous_release_id:
+                  snapshot.release.rollbackConfidence.replayedPreviousReleaseId,
+              }
+            : {}),
+          ...(snapshot.release.rollbackConfidence.replayedPreviousArtifactRef
+            ? {
+                replayed_previous_artifact_ref:
+                  snapshot.release.rollbackConfidence.replayedPreviousArtifactRef,
+              }
+            : {}),
+        },
         receipt_health: {
           status: snapshot.release.receiptHealth.status,
           contract_version: snapshot.release.receiptHealth.contractVersion,
@@ -345,6 +367,7 @@ function printProofText(payload: ReturnType<typeof serializeProofPayload>): void
   }
   if (payload.release) {
     console.log(`- rollbackReady: ${payload.release.rollback_ready ? "yes" : "no"}`);
+    console.log(`- rollbackConfidence: ${payload.release.rollback_confidence.status}`);
     console.log(
       `- receiptContractVersion: ${payload.release.receipt_health.contract_version}`,
     );
@@ -361,6 +384,14 @@ function printProofText(payload: ReturnType<typeof serializeProofPayload>): void
     );
     console.log(
       `- releaseReplay: ${payload.release.replay_verification.ok ? "verified" : "degraded"} (${payload.release.replay_verification.applied_receipts} receipts applied)`,
+    );
+  }
+  if (
+    payload.release &&
+    payload.release.rollback_confidence.issues.length > 0
+  ) {
+    console.log(
+      `- rollbackConfidenceIssues: ${payload.release.rollback_confidence.issues.join("; ")}`,
     );
   }
   if (payload.release?.latest_receipt) {
@@ -540,6 +571,7 @@ export async function runStatusCommand(
   }
   if (releaseEvidence) {
     console.log(`- rollbackReady: ${releaseEvidence.rollbackReady ? "yes" : "no"}`);
+    console.log(`- rollbackConfidence: ${releaseEvidence.rollbackConfidence.status}`);
     console.log(
       `- receiptContractVersion: ${releaseEvidence.receiptHealth.contractVersion}`,
     );
@@ -548,6 +580,14 @@ export async function runStatusCommand(
     );
     console.log(
       `- releaseReplay: ${releaseEvidence.replayVerification.ok ? "verified" : "degraded"} (${releaseEvidence.replayVerification.appliedReceipts} receipts applied)`,
+    );
+  }
+  if (
+    releaseEvidence &&
+    releaseEvidence.rollbackConfidence.issues.length > 0
+  ) {
+    console.log(
+      `- rollbackConfidenceIssues: ${releaseEvidence.rollbackConfidence.issues.join("; ")}`,
     );
   }
   if (releaseEvidence?.latestReceipt) {

--- a/src/core/release-state.ts
+++ b/src/core/release-state.ts
@@ -46,12 +46,20 @@ export interface ReleaseReceiptHealthSummary {
   missingLatestReceipt: boolean;
 }
 
+export interface ReleaseRollbackConfidenceSummary {
+  status: "ready" | "degraded";
+  issues: string[];
+  replayedPreviousReleaseId?: string;
+  replayedPreviousArtifactRef?: string;
+}
+
 export interface ReleaseOperatorEvidence {
   current?: ReleaseRecord;
   previous?: ReleaseRecord;
   rollbackTarget?: ReleaseRollbackTarget;
   receiptsDir: string;
   rollbackReady: boolean;
+  rollbackConfidence: ReleaseRollbackConfidenceSummary;
   latestReceipt?: ReleaseReceiptSummary;
   latestRollbackReceipt?: ReleaseReceiptSummary;
   receiptHealth: ReleaseReceiptHealthSummary;
@@ -175,6 +183,33 @@ async function readReleaseRecord(
   };
 }
 
+async function readReleaseRecordById(
+  rootDir: string,
+  appName: string,
+  releaseId: string | undefined,
+): Promise<ReleaseRecord | undefined> {
+  if (!isNonEmptyString(releaseId)) {
+    return undefined;
+  }
+
+  const metadataPath = path.join(
+    rootDir,
+    ".lifeline",
+    "releases",
+    appName,
+    releaseId,
+    "metadata.json",
+  );
+  const metadata = await readReleaseMetadata(metadataPath);
+
+  return {
+    releaseId,
+    updatedAt: "",
+    ...(metadata?.artifactRef ? { artifactRef: metadata.artifactRef } : {}),
+    ...(metadata ? { metadataPath: normalizeRelativePath(rootDir, metadataPath) } : {}),
+  };
+}
+
 async function readLatestReceipts(
   rootDir: string,
   receiptsDir: string,
@@ -288,12 +323,72 @@ export async function readReleaseOperatorEvidence(
     : undefined;
   const [{ latestReceipts, latestReceipt, receiptHealth }, replayVerification] =
     await Promise.all([
-    readLatestReceipts(resolvedRoot, receiptsDir),
-    verifyWave1ReleaseReplay(appName, resolvedRoot),
+      readLatestReceipts(resolvedRoot, receiptsDir),
+      verifyWave1ReleaseReplay(appName, resolvedRoot),
     ]);
+  const replayedPreviousRecord = await readReleaseRecordById(
+    resolvedRoot,
+    appName,
+    replayVerification.replayedPrevious?.releaseId,
+  );
   const latestRollbackReceipt = latestReceipts.find(
     (receipt) => receipt.action === "rollback",
   );
+
+  const rollbackConfidenceIssues: string[] = [];
+  const rollbackTarget = currentMetadata?.rollbackTarget;
+  if (!rollbackTarget) {
+    rollbackConfidenceIssues.push("rollback target metadata is missing");
+  }
+  if (!replayVerification.ok) {
+    rollbackConfidenceIssues.push(
+      "release replay is degraded, so rollback evidence cannot be trusted",
+    );
+  }
+  if (!replayVerification.replayedPrevious?.releaseId) {
+    rollbackConfidenceIssues.push(
+      "replayed previous-release evidence is missing",
+    );
+  }
+  if (
+    rollbackTarget &&
+    replayVerification.replayedPrevious?.releaseId &&
+    rollbackTarget.releaseId !== replayVerification.replayedPrevious.releaseId
+  ) {
+    rollbackConfidenceIssues.push(
+      `rollback target releaseId ${rollbackTarget.releaseId} does not match replayed previous release ${replayVerification.replayedPrevious.releaseId}`,
+    );
+  }
+  if (
+    rollbackTarget &&
+    replayedPreviousRecord &&
+    replayedPreviousRecord.artifactRef &&
+    rollbackTarget.artifactRef !== replayedPreviousRecord.artifactRef
+  ) {
+    rollbackConfidenceIssues.push(
+      `rollback target artifactRef ${rollbackTarget.artifactRef} does not match replayed previous artifact ${replayedPreviousRecord.artifactRef}`,
+    );
+  }
+  if (
+    rollbackTarget &&
+    replayVerification.replayedPrevious?.releaseId &&
+    !replayedPreviousRecord?.artifactRef
+  ) {
+    rollbackConfidenceIssues.push(
+      `replayed previous release ${replayVerification.replayedPrevious.releaseId} is missing persisted artifact metadata`,
+    );
+  }
+
+  const rollbackConfidence: ReleaseRollbackConfidenceSummary = {
+    status: rollbackConfidenceIssues.length === 0 ? "ready" : "degraded",
+    issues: rollbackConfidenceIssues,
+    ...(replayVerification.replayedPrevious?.releaseId
+      ? { replayedPreviousReleaseId: replayVerification.replayedPrevious.releaseId }
+      : {}),
+    ...(replayedPreviousRecord?.artifactRef
+      ? { replayedPreviousArtifactRef: replayedPreviousRecord.artifactRef }
+      : {}),
+  };
 
   if (
     !current &&
@@ -312,9 +407,8 @@ export async function readReleaseOperatorEvidence(
     ...(currentMetadata?.rollbackTarget
       ? { rollbackTarget: currentMetadata.rollbackTarget }
       : {}),
-    rollbackReady: Boolean(
-      current && previous && currentMetadata?.rollbackTarget,
-    ),
+    rollbackReady: rollbackConfidence.status === "ready",
+    rollbackConfidence,
     receiptsDir: normalizeRelativePath(resolvedRoot, receiptsDir),
     receiptHealth,
     ...(latestReceipt ? { latestReceipt } : {}),


### PR DESCRIPTION
## Summary
- require rollback readiness to be backed by replayed previous-release evidence instead of rollback-target existence alone
- degrade operator evidence when rollback metadata is stale, missing, or mismatched against replayed previous-release state
- surface rollback confidence state and issue details in status, proof-text, and logs output
- extend deterministic operator evidence coverage for rollback-target drift, stale artifact metadata, replay degradation, and missing previous-release evidence

## Verification
- `pnpm build`
- `node scripts/test-wave1-release-cli-deterministic.mjs`
- `node scripts/test-wave1-operator-evidence-deterministic.mjs`
- `pnpm run verify`

## Notes
- no ATLAS/Foundation/Playbook/Cortex/app repo changes
- no broad runtime expansion
- rollback execution behavior is unchanged; this tranche hardens readiness/evidence reporting only