### PR TITLE
Docs: add Lifeline release safety closeout checkpoint

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-05-20
+
+- Added a release-safety closeout checkpoint covering merged Wave 1, Wave 2, and Wave 3 hardening across release replay evidence, destructive pointer confirmations, receipt health, replay proof, and rollback confidence.
+- WHY: Lifeline reached a stable release/operator safety plateau and needed one bounded checkpoint before opening a new execution lane or switching focus to sustain work elsewhere in the stack.
+
 ## 2026-04-01
 
 - Added deterministic Wave 2 startup verification (`pnpm test:startup-deterministic`) that checks restore entrypoint wiring, startup command planning, and startup registration-state inspection without requiring reboot simulation.

--- a/docs/lifeline-release-safety-closeout-2026-05-20.md
+++ b/docs/lifeline-release-safety-closeout-2026-05-20.md
@@ -1,0 +1,49 @@
+# Lifeline Release Safety Closeout
+
+Date: 2026-05-20
+
+## Scope
+
+This checkpoint closes the current Lifeline release-safety tranche without widening runtime authority.
+
+Included:
+- Wave 1 release replay and operator evidence hardening
+- Wave 2 destructive pointer confirmation and receipt-health visibility
+- Wave 3 rollback-confidence evidence
+
+Excluded:
+- hosted control-plane behavior
+- cross-repo execution authority
+- ATLAS root topology changes
+- Foundation, Playbook, Cortex, or app-repo source work
+
+## Landed State
+
+Release/operator safety now has three merged guardrail layers:
+
+1. replay evidence
+   - immutable release receipts are replayed and compared against persisted current/previous pointers
+   - malformed, wrong-version, unreadable, or duplicate release receipts degrade operator evidence
+
+2. pointer mutation safety
+   - `lifeline release activate` and `lifeline release rollback` require explicit confirmation in interactive sessions
+   - receipt health, latest receipt evidence, and replay proof are surfaced in `status`, `--proof-text`, and `logs`
+
+3. rollback confidence
+   - `rollbackReady` now depends on rollback-target metadata matching replayed previous-release evidence
+   - stale, missing, or mismatched rollback metadata degrades operator evidence instead of silently appearing ready
+
+## Verification Baseline
+
+The current release-safety baseline is:
+
+```text
+pnpm build
+node scripts/test-wave1-release-cli-deterministic.mjs
+node scripts/test-wave1-operator-evidence-deterministic.mjs
+pnpm run verify
+```
+
+## Next Queue
+
+Lifeline can pause here and hand off to sustain work, or reopen only for another bounded release-safety tranche. The next lane should not broaden runtime authority by default.


### PR DESCRIPTION
## Summary
- add a dated closeout note for the merged Lifeline release-safety tranche
- record the landed Wave 1, Wave 2, and Wave 3 guardrails without reopening runtime work
- add a changelog entry so the checkpoint is discoverable from the normal docs surface

## Verification
- `pnpm run verify`

## Notes
- docs-only checkpoint
- no runtime authority changes
- no ATLAS/Foundation/Playbook/Cortex/app repo changes