### PR TITLE
docs: reduce path discipline warning residue

### DIFF
--- a/docs/naming-blocker-compression-pass-2.md
+++ b/docs/naming-blocker-compression-pass-2.md
@@ -1,0 +1,140 @@
+# Lifeline Naming-Blocker Compression Pass 2
+
+- Date: `2026-05-28`
+- Repo: `fawxzzy-lifeline`
+- Mode: `owner-side local repo execution only`
+- Scope: `lifeline only`
+
+## Objective
+
+Reduce lifeline's current naming blocker from `active owner-side release lane closeout` to either:
+
+- `safe-next-candidate ready`
+- or one exact remaining blocker only
+
+This pass does not:
+
+- rename the repo
+- touch ATLAS root docs
+- touch any other repo
+- perform any remote mutation
+
+## Source Read
+
+Reread before execution:
+
+- `docs/naming-blocker-conversion-assessment-pass-1.md`
+- `<ATLAS_ROOT>/docs/ops/ATLAS-OWNED-REPO-NAMING-REMAINING-FAMILY-DELTA-RECHECK-PASS-2-2026-05-28.md`
+
+## Starting Blocker Class
+
+Starting blocker class from pass 1:
+
+- `blocked by active owner-side release lane closeout`
+
+Starting active repo facts:
+
+- active repo branch: `codex/lifeline-release-replay-verification`
+- active repo dirty state:
+  - tracked `.codex/**` deletions
+  - tracked `README.md` link addition
+  - untracked `docs/history/` bundle
+- local `main` was clean in a separate worktree
+- eight extra clean lifeline worktrees were still registered
+
+## Work Performed
+
+This pass collapsed the blocker with the smallest coherent owner-side slice:
+
+1. restored the tracked `.codex/**` files instead of letting accidental local deletions continue to define the lane
+2. preserved the intentional doc/history residue on the existing release-verification branch as one local commit:
+   - branch: `codex/lifeline-release-replay-verification`
+   - commit: `3b1e17ae240e7b69bd4fbfddf577ceecdb48e3bd`
+   - subject: `docs: preserve release history bundle`
+3. removed the clean dedicated `main` worktree so the repo root could normalize back onto `main`
+4. removed the remaining clean registered lifeline worktrees from git worktree registration
+5. deleted the eight resulting clean stranded directories under `<ATLAS_TMP>/*` after deregistration succeeded
+6. restored the repo root worktree to local `main`
+7. repaired the local dependency toolchain with `pnpm install --frozen-lockfile`
+8. ran repo-local verification with `pnpm run verify`
+
+No remote mutation was performed.
+
+## Resulting Posture
+
+Current active repo posture:
+
+- active repo branch: `main`
+- active repo commit: `31ef3ad92c775810b19cc565820664f3476a6719`
+- active repo dirty state: `clean`
+- registered extra worktrees: `none`
+- repo-local verification: `passed`
+
+Preserved owner-side release-lane evidence:
+
+- local branch `codex/lifeline-release-replay-verification` remains available
+- preserved local docs commit: `3b1e17ae240e7b69bd4fbfddf577ceecdb48e3bd`
+
+Removed worktree / retained-surface pressure:
+
+- `<ATLAS_TMP>/fawxzzy-lifeline-rollback-rehearsal-evidence`
+- `<ATLAS_TMP>/lifeline-closeout-checkpoint`
+- `<ATLAS_TMP>/lifeline-main-closeout-24`
+- `<ATLAS_TMP>/lifeline-pr24-refresh`
+- `<ATLAS_TMP>/lifeline-release-cli-guardrails-worktree`
+- `<ATLAS_TMP>/lifeline-release-replay-verification-clean`
+- `<ATLAS_TMP>/lifeline-wave2-scout`
+- `<ATLAS_TMP>/lifeline-wave3-scout`
+
+## Exact Blocker Class After This Pass
+
+Exact blocker class now:
+
+- `none`
+
+Why:
+
+- the active repo worktree is back on `main`
+- the active repo worktree is clean
+- the prior release-lane residue has been preserved on its local branch instead of remaining as working-tree drift
+- the extra clean lifeline worktree family is no longer registered
+- the stranded directories left by worktree deregistration have been removed
+
+## Safe-Next-Candidate Readiness
+
+Safe-next-candidate ready:
+
+- `yes`
+
+Why:
+
+- lifeline now matches the bounded local rename preflight shape already proven by prior naming packets
+- no active worktree or retained-surface pressure remains in the local lifeline family
+- verification is green on the normalized repo-root `main` worktree
+
+## Exact Next Owner-Side Step
+
+- `none`
+
+Next honest move:
+
+- root-side blocker-class or remaining-family recheck only
+
+## Verification
+
+Repo-local repair and verification commands:
+
+- `pnpm install --frozen-lockfile`
+- `pnpm run verify`
+
+Result:
+
+- `passed`
+
+## Rule
+
+Blocked naming-family repos must be compressed to one exact unblock path before root reopens the family.
+
+## Failure Mode
+
+Lifeline stays generally `release-lane blocked` even after the local lane residue and clean worktree family are already gone.

--- a/docs/naming-blocker-conversion-assessment-pass-1.md
+++ b/docs/naming-blocker-conversion-assessment-pass-1.md
@@ -1,0 +1,144 @@
+# Lifeline Naming-Blocker Conversion Assessment Pass 1
+
+- Date: `2026-05-28`
+- Repo: `fawxzzy-lifeline`
+- Mode: `owner-side local repo execution only`
+- Scope: `lifeline only`
+
+## Objective
+
+Reduce lifeline from a broad blocked naming-family member to one exact owner-side blocker picture.
+
+This pass does not:
+
+- rename the repo
+- touch ATLAS root docs
+- touch any other repo
+- perform any remote mutation
+
+## Source Read
+
+Reread before execution:
+
+- `<ATLAS_ROOT>/docs/ops/ATLAS-OWNED-REPO-NAMING-BLOCKED-STATE-FAMILY-RECHECK-2026-05-28.md`
+
+## Starting Blocker Set
+
+Starting blocker set from the root family recheck:
+
+- active local owner-lane state
+- non-`main` posture
+- dirty worktree / retained-surface pressure
+
+Starting active repo facts:
+
+- active repo branch: `codex/lifeline-release-replay-verification`
+- active repo commit: `4589b4f332247b32e01931907f803e5ea5991e34`
+- active repo dirty state:
+  - deleted local `.codex/**` residue
+  - tracked `README.md` doc link addition
+  - untracked `docs/history/` doc bundle
+- local `main` already exists in a separate clean worktree:
+  - `<ATLAS_TMP>/lifeline-main-closeout-24`
+- extra lifeline worktree family is still live but currently clean:
+  - `<ATLAS_TMP>/fawxzzy-lifeline-rollback-rehearsal-evidence`
+  - `<ATLAS_TMP>/lifeline-closeout-checkpoint`
+  - `<ATLAS_TMP>/lifeline-main-closeout-24`
+  - `<ATLAS_TMP>/lifeline-pr24-refresh`
+  - `<ATLAS_TMP>/lifeline-release-cli-guardrails-worktree`
+  - `<ATLAS_TMP>/lifeline-release-replay-verification-clean`
+  - `<ATLAS_TMP>/lifeline-wave2-scout`
+  - `<ATLAS_TMP>/lifeline-wave3-scout`
+
+## Work Performed
+
+This pass collapsed the blocker by inspecting the smallest coherent owner-side slice:
+
+1. confirmed the active repo is still on a non-`main` release-verification branch
+2. confirmed the active dirty surface is narrow and concrete rather than stack-wide
+3. confirmed the extra lifeline worktree family is real but currently clean
+4. confirmed local `main` already has a clean dedicated worktree for later normalization
+5. ran repo-local verification with `pnpm run verify`
+
+No remote mutation was performed.
+
+## Resulting Posture
+
+Current active repo posture:
+
+- active repo branch: `codex/lifeline-release-replay-verification`
+- active repo commit: `4589b4f332247b32e01931907f803e5ea5991e34`
+- active repo dirty state:
+  - deleted local `.codex/**` residue
+  - tracked `README.md` doc link addition
+  - untracked `docs/history/` doc bundle
+- local `main` worktree posture:
+  - path: `<ATLAS_TMP>/lifeline-main-closeout-24`
+  - state: `clean`
+- repo-local verification: `passed`
+
+## Exact Blocker Class After This Pass
+
+Exact blocker class now:
+
+- `blocked by active owner-side release lane closeout`
+
+Why this is now one exact blocker class:
+
+- the non-`main` posture is not a separate abstract blocker
+- the dirty active worktree surface is not a separate abstract blocker
+- the extra clean worktrees are not a separate abstract blocker
+
+All three facts belong to one still-live owner-side release lane centered on `codex/lifeline-release-replay-verification` and its adjacent release-safety worktree family.
+
+That makes the remaining blocker a closeout/preservation decision for one exact owner-side lane, not generic path uncertainty.
+
+## Safe-Third Candidate Readiness
+
+Safe-third candidate ready:
+
+- `no`
+
+Plausibly ready soon:
+
+- `yes`
+
+Why:
+
+- lifeline already has a clean local `main` worktree available
+- the remaining active pressure is concrete and local
+- the remaining blocker is small enough to collapse in one follow-up closeout pass if the current release lane is intentionally preserved or closed
+
+## Exact Minimum Remaining Blocker Set
+
+Minimum remaining blocker set:
+
+1. decide whether the active `codex/lifeline-release-replay-verification` lane should be preserved or closed out
+2. resolve the active repo dirty surface as part of that single lane decision:
+   - deleted local `.codex/**` residue
+   - tracked `README.md` link change
+   - untracked `docs/history/` bundle
+3. reduce the extra clean lifeline worktree family to the smallest intentional preserved set after the active lane decision
+4. rerun one exact lifeline blocker-class recheck after that closeout
+
+## Exact Next Owner-Side Step
+
+`close out or intentionally preserve the active codex/lifeline-release-replay-verification lane, including its README/docs-history/.codex residue, then reduce the extra clean worktree family to the smallest intentional preserved set`
+
+## Verification
+
+Repo-local verification command:
+
+- `pnpm run verify`
+
+Result:
+
+- `passed`
+
+## Rule
+
+Assessment must reduce lifeline from active local owner-lane state to a concrete unblock path.
+
+## Failure Mode
+
+Lifeline stays generically dirty/non-`main` with no exact unblock sequence.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - "."
+
+allowBuilds:
+  "@biomejs/biome": true

--- a/qa/adapters/lifeline.package.json
+++ b/qa/adapters/lifeline.package.json
@@ -2,7 +2,7 @@
   "contract_version": "atlas.qa.adapter.v1",
   "adapter_id": "lifeline.package",
   "repo_id": "lifeline",
-  "repo_path": "repos/fawxzzy-lifeline",
+  "repo_path": "repos/lifeline",
   "framework": "service-or-package",
   "lens_manifest_ref": "ops/atlas/qa/lenses/atlas-default-web.v1.json",
   "commands": {

--- a/qa/scenarios/lifeline.contract-smoke.json
+++ b/qa/scenarios/lifeline.contract-smoke.json
@@ -4,7 +4,7 @@
   "title": "Lifeline package contract smoke",
   "summary": "Repo-owned Lifeline QA intent for deterministic contract and verify evidence.",
   "repo_id": "lifeline",
-  "repo_path": "repos/fawxzzy-lifeline",
+  "repo_path": "repos/lifeline",
   "adapter_id": "lifeline.package",
   "criticality": "high",
   "tags": [


### PR DESCRIPTION
## Summary
- normalize machine-specific ATLAS root and tmp path references in the preserved naming-blocker receipts
- preserve the ignored receipt docs as committed repo-local evidence
- publish the Lifeline owner-repo warning reduction slice

## Verification
- `pnpm run verify`
- `python .\ops\validation\validate_stack.py --ratchet`

## Notes
- local verification also required repairing a stale local `node_modules/typescript` junction that still pointed at the old `fawxzzy-lifeline` repo path; that was a local toolchain fix only and is not part of the committed diff
- current ATLAS root validator posture after this slice: `critical=0 error=7 warning=106 info=0`
